### PR TITLE
use React.cloneElement API, fix this.children are multiple elments will crash bug.

### DIFF
--- a/lib/NavLink.js
+++ b/lib/NavLink.js
@@ -109,8 +109,8 @@ var NavLink = React.createClass({
             if ('string' === typeof this.props.children) {
                 children = this.props.children;
             } else {
-                children = React.addons.cloneWithProps(this.props.children, {
-                    isActive: isActive
+                children = React.Children.map(this.props.children, function (child) {
+                    return React.cloneElement(child, {isActive: isActive});
                 });
             }
         }


### PR DESCRIPTION
if NavLink contain multiple elements will throw error.
```html
<NavLink routeName="home">
     <i>yeah</i>
     <span>haha</span>
</NavLink>
```
```js
//Uncaught TypeError: Cannot read property 'hasOwnProperty' of undefined
```
and React.addons.cloneWithProps is deprecated. Use React.cloneElement instead.