### PR TITLE
[wip] added ability to rewrite the route

### DIFF
--- a/lib/NavLink.js
+++ b/lib/NavLink.js
@@ -93,14 +93,6 @@ var NavLink = React.createClass({
             params: this.props.navParams
         });
     },
-    shouldComponentUpdate: function (nextProps) {
-        return (
-            this.props.href !== nextProps.href ||
-            this.props.routeName !== nextProps.routeName ||
-            this.props.navParams !== nextProps.navParams ||
-            !Immutable.is(this.props.currentRoute, nextProps.currentRoute)
-        );
-    },
     render: function() {
         var href = this._getHrefFromProps(this.props);
         var isActive = this.props.isActive(href);

--- a/lib/RouteStore.js
+++ b/lib/RouteStore.js
@@ -3,6 +3,7 @@
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 'use strict';
+var debug = require('debug')('RouteStore');
 var createStore = require('fluxible/addons/createStore');
 var Router = require('routr');
 var queryString = require('query-string');
@@ -15,7 +16,8 @@ var RouteStore = createStore({
     storeName: 'RouteStore',
     handlers: {
         'NAVIGATE_START': 'handleNavigateStart',
-        'RECEIVE_ROUTES': 'handleReceiveRoutes'
+        'RECEIVE_ROUTES': 'handleReceiveRoutes',
+        'REWRITE_ROUTE': 'handleRewriteRoute'
     },
     initialize: function () {
         this.routes = null;
@@ -23,20 +25,51 @@ var RouteStore = createStore({
         this.currentRoute = null;
         this.currentNavigate = null;
         this.router = null;
+        this.isRewrite = null;
+        this.rewriteRouteName = null;
     },
     handleNavigateStart: function (payload) {
+        debug('handleNavigateStart called with payload', payload);
+
         var options = {
             navigate: payload,
             method: payload.method
         };
+        var matchedRoute = this._matchRoute(payload.url, options);
 
         this.currentUrl = payload.url;
-        var matchedRoute = this._matchRoute(payload.url, options);
+
         if (!Immutable.is(matchedRoute, this.currentRoute)) {
+            debug('handleNavigateStart changing route', matchedRoute);
+
             this.currentRoute = matchedRoute;
             this.currentNavigate = payload;
+            this.isRewrite = false;
+            this.rewriteRouteName = null;
             this.emitChange();
+            return;
         }
+
+        debug('handleNavigateStart route not changed');
+    },
+    handleRewriteRoute: function (payload) {
+        var route = this._makeRewriteRoute(payload.name, payload.route);
+
+        this.currentRoute = route;
+        this.isRewrite = true;
+        this.rewriteRouteName = payload.name;
+        this.emitChange();
+    },
+    _makeRewriteRoute: function (name, route) {
+        var self = this;
+        var myRoute = Immutable.fromJS(route).withMutations(function (r) {
+            r.set('name', name);
+            r.set('url', self.currentRoute && self.currentRoute.get('url'));
+            r.set('params', self.currentRoute && self.currentRoute.get('params'));
+            r.set('query', self.currentRoute && self.currentRoute.get('query'));
+        });
+
+        return myRoute;
     },
     _matchRoute: function (url, options) {
         var self = this;
@@ -92,16 +125,28 @@ var RouteStore = createStore({
     },
     dehydrate: function () {
         return {
+            routes: this.routes,
             currentUrl: this.currentUrl,
             currentNavigate: this.currentNavigate,
-            routes: this.routes
+            isRewrite: this.isRewrite,
+            rewriteRouteName: this.rewriteRouteName
         };
     },
     rehydrate: function (state) {
+        debug('rehydrating', state);
         this.routes = state.routes;
         this.currentUrl = state.currentUrl;
-        this.currentRoute = this._matchRoute(this.currentUrl, {method: 'GET'});
+        if (state.isRewrite) {
+            var routes = this.routes || this.constructor.routes;
+            var name = state.rewriteRouteName;
+            this.currentRoute = this._makeRewriteRoute(name, routes[name]);
+        }
+        else {
+            this.currentRoute = this._matchRoute(this.currentUrl, {method: 'GET'});
+        }
         this.currentNavigate = state.currentNavigate;
+        this.isRewrite = state.isRewrite;
+        this.rewriteRouteName = this.rewriteRouteName;
     }
 });
 

--- a/lib/RouteStore.js
+++ b/lib/RouteStore.js
@@ -15,9 +15,9 @@ var Immutable = require('immutable');
 var RouteStore = createStore({
     storeName: 'RouteStore',
     handlers: {
-        'NAVIGATE_START': 'handleNavigateStart',
-        'RECEIVE_ROUTES': 'handleReceiveRoutes',
-        'REWRITE_ROUTE': 'handleRewriteRoute'
+        'NAVIGATE_START': '_handleNavigateStart',
+        'RECEIVE_ROUTES': '_handleReceiveRoutes',
+        'REWRITE_ROUTE': '_handleRewriteRoute'
     },
     initialize: function () {
         this.routes = null;
@@ -28,7 +28,7 @@ var RouteStore = createStore({
         this.isRewrite = null;
         this.rewriteRouteName = null;
     },
-    handleNavigateStart: function (payload) {
+    _handleNavigateStart: function (payload) {
         debug('handleNavigateStart called with payload', payload);
 
         var options = {
@@ -52,12 +52,18 @@ var RouteStore = createStore({
 
         debug('handleNavigateStart route not changed');
     },
-    handleRewriteRoute: function (payload) {
+    _handleRewriteRoute: function (payload) {
         var route = this._makeRewriteRoute(payload.name, payload.route);
 
         this.currentRoute = route;
         this.isRewrite = true;
         this.rewriteRouteName = payload.name;
+        this.emitChange();
+    },
+    _handleReceiveRoutes: function (payload) {
+        this.routes = objectAssign(this.routes || {}, payload);
+        // Reset the router so that it is recreated next time it's needed
+        this.router = null;
         this.emitChange();
     },
     _makeRewriteRoute: function (name, route) {
@@ -95,12 +101,6 @@ var RouteStore = createStore({
             search = matches[1];
         }
         return (search && queryString.parse(search)) || {};
-    },
-    handleReceiveRoutes: function (payload) {
-        this.routes = objectAssign(this.routes || {}, payload);
-        // Reset the router so that it is recreated next time it's needed
-        this.router = null;
-        this.emitChange();
     },
     makePath: function (routeName, params) {
         return this.getRouter().makePath(routeName, params);

--- a/lib/handleHistory.js
+++ b/lib/handleHistory.js
@@ -60,8 +60,7 @@ module.exports = function handleHistory(Component, opts) {
 
         componentDidMount: function () {
             if (historyCreated) {
-                throw new Error('Only one history handler should be on the ' +
-                'page at a time.');
+                throw new Error('Only one history handler should be on the page at a time.');
             }
             this._history = options.historyCreator();
             this._scrollTimer = null;

--- a/tests/unit/lib/History-test.js
+++ b/tests/unit/lib/History-test.js
@@ -3,11 +3,11 @@
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 /*globals describe,it,before,beforeEach */
-var History = require('../../../lib/History'),
-    expect = require('chai').expect,
-    _ = require('lodash'),
-    windowMock,
-    testResult;
+var History = require('../../../lib/History');
+var expect = require('chai').expect;
+var _ = require('lodash');
+var windowMock;
+var testResult;
 
 
 describe('History', function () {

--- a/tests/unit/lib/NavLink-test.js
+++ b/tests/unit/lib/NavLink-test.js
@@ -38,7 +38,7 @@ describe('NavLink', function () {
         mockContext = createMockComponentContext({
             stores: [TestRouteStore]
         });
-        mockContext.getStore('RouteStore').handleNavigateStart({
+        mockContext.getStore('RouteStore')._handleNavigateStart({
             url: '/foo',
             method: 'GET'
         });
@@ -345,7 +345,7 @@ describe('NavLink', function () {
             expect(link.getDOMNode().getAttribute('href')).to.equal('/foo');
             expect(link.getDOMNode().textContent).to.equal('bar');
             expect(link.getDOMNode().getAttribute('class')).to.equal('active');
-            mockContext.getStore('RouteStore').handleNavigateStart({
+            mockContext.getStore('RouteStore')._handleNavigateStart({
                 url: '/bar',
                 method: 'GET'
             });

--- a/tests/unit/lib/RouteStore-test.js
+++ b/tests/unit/lib/RouteStore-test.js
@@ -55,10 +55,26 @@ describe('RouteStore', function () {
 
     describe('withoutStaticRoutes', function () {
         var routeStore;
+        var FooComponent = React.createClass({
+            render: function () {
+                return (<div>Foo!</div>);
+            }
+        });
+        var BarComponent = React.createClass({
+            render: function () {
+                return (<div>Bar!</div>);
+            }
+        });
         var routes = {
             foo: {
                 path: '/foo',
-                method: 'get'
+                method: 'get',
+                handler: FooComponent
+            },
+            bar: {
+                path: '/bar',
+                method: 'get',
+                handler: BarComponent
             }
         };
         beforeEach(function () {
@@ -95,6 +111,17 @@ describe('RouteStore', function () {
                     method: 'get'
                 });
                 expect(newStore.routes).to.deep.equal(routes);
+            });
+            it('should rehydrate with a rewriteen route correctly', function () {
+                var newStore = new StaticRouteStore();
+                newStore.rehydrate({
+                    isRewrite: true,
+                    rewriteRouteName: 'bar',
+                    currentUrl: '/foo',
+                    currentNavigate: { url: '/foo', method: 'get' },
+                    routes: routes
+                });
+                expect(newStore.getCurrentRoute().get('handler').displayName).to.equal('BarComponent');
             });
         });
     });

--- a/tests/unit/lib/RouteStore-test.js
+++ b/tests/unit/lib/RouteStore-test.js
@@ -2,6 +2,7 @@
  * Copyright 2015, Yahoo! Inc.
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
+var React = require('react');
 var expect = require('chai').expect;
 var RouteStore = require('../../../').RouteStore;
 var StaticRouteStore = RouteStore.withStaticRoutes({
@@ -95,6 +96,54 @@ describe('RouteStore', function () {
                 });
                 expect(newStore.routes).to.deep.equal(routes);
             });
+        });
+    });
+
+    describe('rewriteRoute', function () {
+        var routeStore;
+        var FooComponent = React.createClass({
+            render: function () {
+                return (<div>Foo!</div>);
+            }
+        });
+        var BarComponent = React.createClass({
+            render: function () {
+                return (<div>Bar!</div>);
+            }
+        });
+        var routes = {
+            foo: {
+                path: '/foo',
+                method: 'get',
+                handler: FooComponent
+            },
+            bar: {
+                path: '/bar',
+                method: 'get',
+                handler: BarComponent
+            }
+        };
+        beforeEach(function () {
+            routeStore = new RouteStore();
+            routeStore._handleReceiveRoutes(routes);
+            routeStore._handleNavigateStart({
+                url: '/foo',
+                method: 'get'
+            });
+        });
+        it('should rewrite the current route', function () {
+            var CurrentRoute = routeStore.getCurrentRoute();
+            expect(CurrentRoute.get('handler').displayName).to.equal('FooComponent');
+            expect(CurrentRoute.get('url')).to.equal('/foo');
+
+            routeStore._handleRewriteRoute({
+                name: 'bar',
+                route: routes.bar
+            });
+
+            CurrentRoute = routeStore.getCurrentRoute();
+            expect(CurrentRoute.get('handler').displayName).to.equal('BarComponent');
+            expect(CurrentRoute.get('url')).to.equal('/foo');
         });
     });
 

--- a/tests/unit/lib/RouteStore-test.js
+++ b/tests/unit/lib/RouteStore-test.js
@@ -17,7 +17,7 @@ describe('RouteStore', function () {
         var routeStore;
         beforeEach(function () {
             routeStore = new StaticRouteStore();
-            routeStore.handleNavigateStart({
+            routeStore._handleNavigateStart({
                 url: '/foo',
                 method: 'get'
             });
@@ -62,8 +62,8 @@ describe('RouteStore', function () {
         };
         beforeEach(function () {
             routeStore = new RouteStore();
-            routeStore.handleReceiveRoutes(routes);
-            routeStore.handleNavigateStart({
+            routeStore._handleReceiveRoutes(routes);
+            routeStore._handleNavigateStart({
                 url: '/foo',
                 method: 'get'
             });

--- a/tests/unit/lib/handleHistory-test.js
+++ b/tests/unit/lib/handleHistory-test.js
@@ -92,7 +92,7 @@ describe ('handleHistory', function () {
         it('should pass the currentRoute as prop to child', function () {
             var rendered = false;
             var routeStore = mockContext.getStore('RouteStore');
-            routeStore.handleNavigateStart({url: '/foo', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/foo', method: 'GET'});
             var Child = React.createClass({
                 displayName: 'Child',
                 render: function () {
@@ -127,7 +127,7 @@ describe ('handleHistory', function () {
         });
         it ('listen to scroll event', function (done) {
             var routeStore = mockContext.getStore('RouteStore');
-            routeStore.handleNavigateStart({url: '/the_path_from_state', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/the_path_from_state', method: 'GET'});
             MockAppComponent = provideContext(handleHistory(MockAppComponent, {
                 historyCreator: function () {
                     return historyMock();
@@ -145,7 +145,7 @@ describe ('handleHistory', function () {
         });
         it ('dispatch navigate event for pages that url does not match', function (done) {
             var routeStore = mockContext.getStore('RouteStore');
-            routeStore.handleNavigateStart({url: '/the_path_from_state', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/the_path_from_state', method: 'GET'});
             MockAppComponent = provideContext(handleHistory(MockAppComponent, {
                 checkRouteOnPageLoad: true,
                 historyCreator: function () {
@@ -165,7 +165,7 @@ describe ('handleHistory', function () {
         });
         it ('does not dispatch navigate event for pages with matching url', function (done) {
             var routeStore = mockContext.getStore('RouteStore');
-            routeStore.handleNavigateStart({url: '/the_path_from_history', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/the_path_from_history', method: 'GET'});
             MockAppComponent = provideContext(handleHistory(MockAppComponent, {
                 historyCreator: function () {
                     return historyMock('/foo');
@@ -202,7 +202,7 @@ describe ('handleHistory', function () {
     describe('componentDidUpdate()', function () {
         it ('no-op on same route', function () {
             var routeStore = mockContext.getStore('RouteStore');
-            routeStore.handleNavigateStart({url: '/foo', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/foo', method: 'GET'});
             MockAppComponent = provideContext(handleHistory(MockAppComponent, {
                 historyCreator: function () {
                     return historyMock('/foo');
@@ -211,12 +211,12 @@ describe ('handleHistory', function () {
             ReactTestUtils.renderIntoDocument(
                 <MockAppComponent context={mockContext} />
             );
-            routeStore.handleNavigateStart({url: '/foo', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/foo', method: 'GET'});
             expect(testResult.pushState).to.equal(undefined);
         });
         it ('do not pushState, navigate.type=popstate', function () {
             var routeStore = mockContext.getStore('RouteStore');
-            routeStore.handleNavigateStart({url: '/foo', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/foo', method: 'GET'});
             MockAppComponent = provideContext(handleHistory(MockAppComponent, {
                 historyCreator: function () {
                     return historyMock('/foo');
@@ -225,12 +225,12 @@ describe ('handleHistory', function () {
             ReactTestUtils.renderIntoDocument(
                 <MockAppComponent context={mockContext} />
             );
-            routeStore.handleNavigateStart({url: '/bar', type: 'popstate', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/bar', type: 'popstate', method: 'GET'});
             expect(testResult.pushState).to.equal(undefined);
         });
         it ('update with different route, navigate.type=click, reset scroll position', function () {
             var routeStore = mockContext.getStore('RouteStore');
-            routeStore.handleNavigateStart({url: '/foo', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/foo', method: 'GET'});
             MockAppComponent = provideContext(handleHistory(MockAppComponent, {
                 historyCreator: function () {
                     return historyMock('/foo');
@@ -239,13 +239,13 @@ describe ('handleHistory', function () {
             ReactTestUtils.renderIntoDocument(
                 <MockAppComponent context={mockContext} />
             );
-            routeStore.handleNavigateStart({url: '/bar', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/bar', method: 'GET'});
             expect(testResult.pushState).to.eql({state: {params: {}, scroll: {x: 0, y: 0}}, title: null, url: '/bar'});
             expect(testResult.scrollTo).to.eql({x: 0, y: 0});
         });
         it ('update with different route, navigate.type=click, enableScroll=false, do not reset scroll position', function () {
             var routeStore = mockContext.getStore('RouteStore');
-            routeStore.handleNavigateStart({url: '/foo', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/foo', method: 'GET'});
             MockAppComponent = provideContext(handleHistory(MockAppComponent, {
                 enableScroll: false,
                 historyCreator: function () {
@@ -255,13 +255,13 @@ describe ('handleHistory', function () {
             ReactTestUtils.renderIntoDocument(
                 <MockAppComponent context={mockContext} />
             );
-            routeStore.handleNavigateStart({url: '/bar', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/bar', method: 'GET'});
             expect(testResult.pushState).to.eql({state: {params: {}}, title: null, url: '/bar'});
             expect(testResult.scrollTo).to.equal(undefined);
         });
         it ('update with different route, navigate.type=replacestate, enableScroll=false, do not reset scroll position', function () {
             var routeStore = mockContext.getStore('RouteStore');
-            routeStore.handleNavigateStart({url: '/foo', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/foo', method: 'GET'});
             MockAppComponent = provideContext(handleHistory(MockAppComponent, {
                 enableScroll: false,
                 historyCreator: function () {
@@ -271,13 +271,13 @@ describe ('handleHistory', function () {
             ReactTestUtils.renderIntoDocument(
                 <MockAppComponent context={mockContext} />
             );
-            routeStore.handleNavigateStart({url: '/bar', method: 'GET', type: 'replacestate'});
+            routeStore._handleNavigateStart({url: '/bar', method: 'GET', type: 'replacestate'});
             expect(testResult.replaceState).to.eql({state: {params: {}}, title: null, url: '/bar'});
             expect(testResult.scrollTo).to.equal(undefined);
         });
         it ('update with different route, navigate.type=default, reset scroll position', function () {
             var routeStore = mockContext.getStore('RouteStore');
-            routeStore.handleNavigateStart({url: '/foo', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/foo', method: 'GET'});
             MockAppComponent = provideContext(handleHistory(MockAppComponent, {
                 historyCreator: function () {
                     return historyMock('/foo');
@@ -286,13 +286,13 @@ describe ('handleHistory', function () {
             ReactTestUtils.renderIntoDocument(
                 <MockAppComponent context={mockContext} />
             );
-            routeStore.handleNavigateStart({url: '/bar', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/bar', method: 'GET'});
             expect(testResult.pushState).to.eql({state: {params: {}, scroll: {x: 0, y: 0} }, title: null, url: '/bar'});
             expect(testResult.scrollTo).to.eql({x: 0, y: 0});
         });
         it ('update with different route, navigate.type=default, enableScroll=false, do not reset scroll position', function () {
             var routeStore = mockContext.getStore('RouteStore');
-            routeStore.handleNavigateStart({url: '/foo', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/foo', method: 'GET'});
             MockAppComponent = provideContext(handleHistory(MockAppComponent, {
                 enableScroll: false,
                 historyCreator: function () {
@@ -302,13 +302,13 @@ describe ('handleHistory', function () {
             ReactTestUtils.renderIntoDocument(
                 <MockAppComponent context={mockContext} />
             );
-            routeStore.handleNavigateStart({url: '/bar', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/bar', method: 'GET'});
             expect(testResult.pushState).to.eql({state: {params: {}}, title: null, url: '/bar'});
             expect(testResult.scrollTo).to.equal(undefined);
         });
         it ('do not pushState, navigate.type=popstate, restore scroll position', function () {
             var routeStore = mockContext.getStore('RouteStore');
-            routeStore.handleNavigateStart({url: '/foo', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/foo', method: 'GET'});
             MockAppComponent = provideContext(handleHistory(MockAppComponent, {
                 historyCreator: function () {
                     return historyMock('/foo#hash1', {scroll: {x: 12, y: 200}});
@@ -317,13 +317,13 @@ describe ('handleHistory', function () {
             ReactTestUtils.renderIntoDocument(
                 <MockAppComponent context={mockContext} />
             );
-            routeStore.handleNavigateStart({url: '/bar', method: 'GET', type: 'popstate'});
+            routeStore._handleNavigateStart({url: '/bar', method: 'GET', type: 'popstate'});
             expect(testResult.pushState).to.equal(undefined);
             expect(testResult.scrollTo).to.eql({x: 12, y: 200});
         });
         it ('do not pushState, navigate.type=popstate, enableScroll=false, restore scroll position', function () {
             var routeStore = mockContext.getStore('RouteStore');
-            routeStore.handleNavigateStart({url: '/foo', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/foo', method: 'GET'});
             MockAppComponent = provideContext(handleHistory(MockAppComponent, {
                 enableScroll: false,
                 historyCreator: function () {
@@ -333,14 +333,14 @@ describe ('handleHistory', function () {
             ReactTestUtils.renderIntoDocument(
                 <MockAppComponent context={mockContext} />
             );
-            routeStore.handleNavigateStart({url: '/bar', method: 'GET', type: 'popstate'});
+            routeStore._handleNavigateStart({url: '/bar', method: 'GET', type: 'popstate'});
             expect(testResult.pushState).to.equal(undefined);
             expect(testResult.scrollTo).to.eql(undefined);
 
         });
         it ('update with different route, navigate.type=click, with params', function () {
             var routeStore = mockContext.getStore('RouteStore');
-            routeStore.handleNavigateStart({url: '/foo', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/foo', method: 'GET'});
             MockAppComponent = provideContext(handleHistory(MockAppComponent, {
                 historyCreator: function () {
                     return historyMock('/foo#hash1');
@@ -349,12 +349,12 @@ describe ('handleHistory', function () {
             ReactTestUtils.renderIntoDocument(
                 <MockAppComponent context={mockContext} />
             );
-            routeStore.handleNavigateStart({url: '/bar', type: 'click', params: {foo: 'bar'}});
+            routeStore._handleNavigateStart({url: '/bar', type: 'click', params: {foo: 'bar'}});
             expect(testResult.pushState).to.eql({state: {params: {foo: 'bar'}, scroll: {x: 0, y:0}}, title: null, url: '/bar'});
         });
         it ('update with same path and different hash, navigate.type=click, with params', function () {
             var routeStore = mockContext.getStore('RouteStore');
-            routeStore.handleNavigateStart({url: '/foo#hash1', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/foo#hash1', method: 'GET'});
             MockAppComponent = provideContext(handleHistory(MockAppComponent, {
                 historyCreator: function () {
                     return historyMock('/foo#hash1');
@@ -363,12 +363,12 @@ describe ('handleHistory', function () {
             ReactTestUtils.renderIntoDocument(
                 <MockAppComponent context={mockContext} />
             );
-            routeStore.handleNavigateStart({url: '/foo#hash2', type: 'click', params: {foo: 'bar'}});
+            routeStore._handleNavigateStart({url: '/foo#hash2', type: 'click', params: {foo: 'bar'}});
             expect(testResult.pushState).to.eql({state: {params: {foo: 'bar'}, scroll: {x: 0, y:0}}, title: null, url: '/foo#hash2'});
         });
         it ('update with different route, navigate.type=replacestate, with params', function () {
             var routeStore = mockContext.getStore('RouteStore');
-            routeStore.handleNavigateStart({url: '/foo', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/foo', method: 'GET'});
             MockAppComponent = provideContext(handleHistory(MockAppComponent, {
                 historyCreator: function () {
                     return historyMock('/foo');
@@ -377,12 +377,12 @@ describe ('handleHistory', function () {
             ReactTestUtils.renderIntoDocument(
                 <MockAppComponent context={mockContext} />
             );
-            routeStore.handleNavigateStart({url: '/bar', method: 'GET', type: 'replacestate', params: {foo: 'bar'}});
+            routeStore._handleNavigateStart({url: '/bar', method: 'GET', type: 'replacestate', params: {foo: 'bar'}});
             expect(testResult.replaceState).to.eql({state: {params: {foo: 'bar'}, scroll: {x: 0, y: 0}}, title: null, url: '/bar'});
         });
         it ('update with different route, navigate.type=replacestate', function () {
             var routeStore = mockContext.getStore('RouteStore');
-            routeStore.handleNavigateStart({url: '/foo', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/foo', method: 'GET'});
             MockAppComponent = provideContext(handleHistory(MockAppComponent, {
                 historyCreator: function () {
                     return historyMock('/foo', {scroll: {x: 42, y: 3}});
@@ -391,14 +391,14 @@ describe ('handleHistory', function () {
             ReactTestUtils.renderIntoDocument(
                 <MockAppComponent context={mockContext} />
             );
-            routeStore.handleNavigateStart({url: '/bar', method: 'GET', type: 'replacestate'});
+            routeStore._handleNavigateStart({url: '/bar', method: 'GET', type: 'replacestate'});
             expect(testResult.replaceState).to.eql({state: {params: {}, scroll: {x: 0, y: 0}}, title: null, url: '/bar'});
         });
         it ('update with different route, navigate.type=pushstate, preserve scroll state', function () {
             global.window.scrollX = 42;
             global.window.scrollY = 3;
             var routeStore = mockContext.getStore('RouteStore');
-            routeStore.handleNavigateStart({url: '/foo', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/foo', method: 'GET'});
             MockAppComponent = provideContext(handleHistory(MockAppComponent, {
                 historyCreator: function () {
                     return historyMock('/foo');
@@ -407,14 +407,14 @@ describe ('handleHistory', function () {
             ReactTestUtils.renderIntoDocument(
                 <MockAppComponent context={mockContext} />
             );
-            routeStore.handleNavigateStart({url: '/bar', method: 'GET', type: 'click', preserveScrollPosition: true});
+            routeStore._handleNavigateStart({url: '/bar', method: 'GET', type: 'click', preserveScrollPosition: true});
             expect(testResult.pushState).to.eql({state: {params: {}, scroll: {x: 42, y: 3}}, title: null, url: '/bar'});
         });
         it ('update with different route, navigate.type=replacestate, preserve scroll state', function () {
             global.window.scrollX = 42;
             global.window.scrollY = 3;
             var routeStore = mockContext.getStore('RouteStore');
-            routeStore.handleNavigateStart({url: '/foo', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/foo', method: 'GET'});
             MockAppComponent = provideContext(handleHistory(MockAppComponent, {
                 historyCreator: function () {
                     return historyMock('/foo');
@@ -423,7 +423,7 @@ describe ('handleHistory', function () {
             ReactTestUtils.renderIntoDocument(
                 <MockAppComponent context={mockContext} />
             );
-            routeStore.handleNavigateStart({url: '/bar', method: 'GET', type: 'replacestate', preserveScrollPosition: true});
+            routeStore._handleNavigateStart({url: '/bar', method: 'GET', type: 'replacestate', preserveScrollPosition: true});
             expect(testResult.replaceState).to.eql({state: {params: {}, scroll: {x: 42, y: 3}}, title: null, url: '/bar'});
         });
     });


### PR DESCRIPTION
This allows us to essentially swap out the route handler without changing the URL.

The current use case is to support 404/500 pages. I have a PR for integrating `fluxible-router` into www.fluxible.io to help demonstrate. See: https://github.com/yahoo/fluxible.io/pull/120

 - [x] test for `REWRITE_ROUTE`
 - [ ] better docs for `RouteStore`