### PR TITLE
handling route failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: node_js
 matrix:
   allow_failures:
     - node_js: "0.13"
+    - node_js: "iojs"
 node_js:
   - "iojs"
   - "0.13"

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,64 @@
+# Upgrade Guide
+
+## `flux-router-component` to `fluxible-router`
+
+Be sure to read the [quick start doc](docs/api/quick-start.md). Here we'll be covering the logistical aspects of updating existing apps.
+
+### No more mixins
+
+The mixin we had in `flux-router-component` has been retired in favor of higher-order components. Once a component is wrapped via `handleRoute` (or `handleHistory` which internally uses `handleRoute`) it will be passed props when navigation actions are triggered. See the [`handleRoute` docs](docs/api/handleRoute.md) for details.
+
+### Update `NavLink` imports
+
+If you have imports for the `NavLink` from `flux-router-component` you'll need to update them to import from `fluxible-router`.
+
+```js
+var NavLink = require('flux-router-component').NavLink;
+```
+
+Should now be:
+
+```js
+var NavLink = require('fluxible-router').NavLink;
+```
+
+### Routes become immutable
+
+When a route is matched and passed to your component it is converted into an [immutable](http://facebook.github.io/immutable-js/) object. It's important to realize you'll need to use the `get` methods to access properties instead of accessing them with regular `.` syntax.
+
+```js
+this.props.currentRoute.url
+```
+
+Should now be:
+
+```js
+this.props.currentRoute.get('url')
+```
+
+### Stores
+
+Previously, keeping track of navigation and route changes was done by implementing an `ApplicationStore` or a `PageStore` yourself. We experimented with two approaches.
+
+Our `flux-examples` repo had an `ApplicationStore`. You can see the diff when we upgraded to `fluxible-router` here: https://github.com/yahoo/flux-examples/pull/119/files
+
+Our doc site [fluxible.io](http://fluxible.io) was using a `PageStore`, which is more similar to the `RouteStore` we have in `fluxible-router` today. You can see our diff of our upgrade to `fluxible-router` here: https://github.com/yahoo/fluxible.io/pull/120/files
+
+In general `fluxible-router` ships a `RouteStore` you should be using instead of rolling your own.
+
+
+### Rendering the right component
+
+Previously we experimented with two approaches to choosing which component to render in our application component based on the current route.
+
+Our `flux-examples` repo had a `switch` statement that chose the component based on the current route. You can see the diff when we upgraded to `fluxible-router` here: https://github.com/yahoo/flux-examples/pull/119/files
+
+Our doc site [fluxible.io](http://fluxible.io) was using a `component` property on the route config, which contained the reference to the component that should be rendered for that route. This is similar to the `handler` property we recommend using with `fluxible-router` today. You can see our diff of our upgrade to `fluxible-router` here: https://github.com/yahoo/fluxible.io/pull/120/files
+
+In general you'll see us using a `handler` property with our route config that contains the component we want to render for that route. But you could use any property name you like. There's nothing magical happening internally with regards to components, it's just another property that get's passed around with the route.
+
+### Route config
+
+There are a few properties for a route that are important for `fluxible-router`; `method`, `path`, `pageTitle` (optional) and `action` (optional). Any other properties you define are simply passed along with your route object.
+
+`pageTitle` is a newer addition to a route's config which relives you from having to update `document.title` yourself.

--- a/docs/api/handleRoute.md
+++ b/docs/api/handleRoute.md
@@ -11,6 +11,8 @@ These props will be passed to your component when a `RouteStore` change is emitt
 | Prop | Description |
 |:-----|:------------|
 | `currentNavigate` | The current payload received when `NAVIGATE_START` is dispatched. |
-| `currentRoute` | The config object from the matched route. |
-| `isActive` | A shortcut to `RouteStore.makePath`. See: [`RouteStore`](RouteStore.md). |
+| `currentNavigateError` | An object representing a navigation error. Note: this is not an `Error` object, it will only contain `message` and `statusCode` properties. |
+| `isNavigateComplete` | A boolean representing if the `navigateAction` has completed. Set to `true` after `NAVIGATE_SUCCESS` or `NAVIGATE_FAILURE`. |
+| `currentRoute` | The config object from the matched route (immutable object). |
+| `isActive` | A shortcut to `RouteStore.isActive`. See: [`RouteStore`](RouteStore.md). |
 | `makePath` | A shortcut to `RouteStore.makePath`. See: [`RouteStore`](RouteStore.md). |

--- a/lib/RouteStore.js
+++ b/lib/RouteStore.js
@@ -15,29 +15,50 @@ var searchPattern = /\?([^\#]*)/;
 var RouteStore = createStore({
     storeName: 'RouteStore',
     handlers: {
-        'NAVIGATE_START': 'handleNavigateStart',
-        'RECEIVE_ROUTES': 'handleReceiveRoutes'
+        'NAVIGATE_START': '_handleNavigateStart',
+        'NAVIGATE_SUCCESS': '_handleNavigateSuccess',
+        'NAVIGATE_FAILURE': '_handleNavigateFailure',
+        'RECEIVE_ROUTES': '_handleReceiveRoutes'
     },
     initialize: function () {
-        this.routes = null;
-        this.currentUrl = null;
-        this.currentRoute = null;
-        this.currentNavigate = null;
-        this.router = null;
+        this._routes = null;
+        this._currentUrl = null;
+        this._currentRoute = null;
+        this._currentNavigate = null;
+        this._currentNavigateError = null;
+        this._isNavigateComplete = null;
+        this._router = null;
     },
-    handleNavigateStart: function (payload) {
-        var options = {
+    _handleNavigateStart: function (payload) {
+        var matchedRoute = this._matchRoute(payload.url, {
             navigate: payload,
             method: payload.method
-        };
+        });
 
-        this.currentUrl = payload.url;
-        var matchedRoute = this._matchRoute(payload.url, options);
-        if (!Immutable.is(matchedRoute, this.currentRoute)) {
-            this.currentRoute = matchedRoute;
-            this.currentNavigate = payload;
-            this.emitChange();
+        if (!Immutable.is(matchedRoute, this._currentRoute)) {
+            this._currentRoute = matchedRoute;
+            this._currentNavigate = payload;
         }
+
+        this._currentNavigateError = null;
+        this._isNavigateComplete = false;
+        this._currentUrl = payload.url;
+        this.emitChange();
+    },
+    _handleNavigateSuccess: function (route) {
+        this._isNavigateComplete = true;
+        this.emitChange();
+    },
+    _handleNavigateFailure: function (error) {
+        this._isNavigateComplete = true;
+        this._currentNavigateError = error;
+        this.emitChange();
+    },
+    _handleReceiveRoutes: function (payload) {
+        this._routes = objectAssign(this._routes || {}, payload);
+        // Reset the router so that it is recreated next time it's needed
+        this._router = null;
+        this.emitChange();
     },
     _matchRoute: function (url, options) {
         var self = this;
@@ -64,45 +85,49 @@ var RouteStore = createStore({
         }
         return (search && queryString.parse(search)) || {};
     },
-    handleReceiveRoutes: function (payload) {
-        this.routes = objectAssign(this.routes || {}, payload);
-        // Reset the router so that it is recreated next time it's needed
-        this.router = null;
-        this.emitChange();
-    },
     makePath: function (routeName, params) {
         return this.getRouter().makePath(routeName, params);
     },
     getCurrentRoute: function () {
-        return this.currentRoute;
+        return this._currentRoute;
     },
     getCurrentNavigate: function () {
-        return this.currentNavigate;
+        return this._currentNavigate;
+    },
+    getCurrentNavigateError: function () {
+        return this._currentNavigateError;
+    },
+    isNavigateComplete: function () {
+        return this._isNavigateComplete;
     },
     getRoutes: function () {
-        return this.routes;
+        return this._routes;
     },
     getRouter: function () {
-        if (!this.router) {
-            this.router = new Router(this.getRoutes());
+        if (!this._router) {
+            this._router = new Router(this.getRoutes());
         }
-        return this.router;
+        return this._router;
     },
     isActive: function (href) {
-        return this.currentUrl === href;
+        return this._currentUrl === href;
     },
     dehydrate: function () {
         return {
-            currentUrl: this.currentUrl,
-            currentNavigate: this.currentNavigate,
-            routes: this.routes
+            currentUrl: this._currentUrl,
+            currentNavigate: this._currentNavigate,
+            currentNavigateError: this._currentNavigateError,
+            isNavigateComplete: this._isNavigateComplete,
+            routes: this._routes
         };
     },
     rehydrate: function (state) {
-        this.routes = state.routes;
-        this.currentUrl = state.currentUrl;
-        this.currentRoute = this._matchRoute(this.currentUrl, {method: 'GET'});
-        this.currentNavigate = state.currentNavigate;
+        this._routes = state.routes;
+        this._currentUrl = state.currentUrl;
+        this._currentRoute = this._matchRoute(this._currentUrl, {method: 'GET'});
+        this._currentNavigate = state.currentNavigate;
+        this._isNavigateComplete = state.isNavigateComplete;
+        this._currentNavigateError = state.currentNavigateError;
     }
 });
 
@@ -115,7 +140,7 @@ RouteStore.withStaticRoutes = function (staticRoutes) {
     StaticRouteStore.handlers = RouteStore.handlers;
     StaticRouteStore.routes = staticRoutes || {};
     StaticRouteStore.prototype.getRoutes = function () {
-        return objectAssign({}, StaticRouteStore.routes, this.routes || {});
+        return objectAssign({}, StaticRouteStore.routes, this._routes || {});
     };
     return StaticRouteStore;
 };

--- a/lib/handleHistory.js
+++ b/lib/handleHistory.js
@@ -124,15 +124,17 @@ module.exports = function handleHistory(Component, opts) {
 
             historyCreated = false;
         },
-        shouldComponentUpdate: function (nextProps) {
-            return !Immutable.is(nextProps.currentRoute, this.props.currentRoute);
-        },
         componentDidUpdate: function (prevProps, prevState) {
             debug('component did update', prevState, this.props);
+
             var nav = this.props.currentNavigate;
             var navType = (nav && nav.type) || TYPE_DEFAULT;
             var navParams = nav.params || {};
             var historyState;
+
+            if (nav.url === this._history.getUrl()) {
+                return;
+            }
 
             switch (navType) {
                 case TYPE_CLICK:

--- a/lib/handleRoute.js
+++ b/lib/handleRoute.js
@@ -15,7 +15,9 @@ module.exports = function handleRoute(Component) {
         },
         propTypes: {
             currentRoute: React.PropTypes.object,
-            currentNavigate: React.PropTypes.object
+            currentNavigate: React.PropTypes.object,
+            currentNavigateError: React.PropTypes.object,
+            isNavigateComplete: React.PropTypes.bool
         },
 
         render: function () {
@@ -31,6 +33,8 @@ module.exports = function handleRoute(Component) {
     return connectToStores(RouteHandler, ['RouteStore'], function (stores, props) {
         return {
             currentNavigate: stores.RouteStore.getCurrentNavigate(),
+            currentNavigateError: stores.RouteStore.getCurrentNavigateError(),
+            isNavigateComplete: stores.RouteStore.isNavigateComplete(),
             currentRoute: stores.RouteStore.getCurrentRoute()
         };
     });

--- a/lib/navigateAction.js
+++ b/lib/navigateAction.js
@@ -18,10 +18,13 @@ module.exports = function (context, payload, done) {
     var route = routeStore.getCurrentRoute();
 
     if (!route) {
-        context.dispatch('NAVIGATE_FAILURE', payload);
-        var error = new Error('Url does not exist');
-        error.statusCode = 404;
-        done(error);
+        var error404 = {
+            statusCode: 404,
+            message: 'Url does not exist'
+        };
+
+        context.dispatch('NAVIGATE_FAILURE', error404);
+        done(error404);
         return;
     }
 
@@ -33,7 +36,7 @@ module.exports = function (context, payload, done) {
 
     if (!action || 'function' !== typeof action) {
         debug('route has no action, dispatching without calling action');
-        context.dispatch('NAVIGATE_SUCCESS', payload);
+        context.dispatch('NAVIGATE_SUCCESS', route);
         done();
         return;
     }
@@ -41,10 +44,16 @@ module.exports = function (context, payload, done) {
     debug('executing route action');
     context.executeAction(action, route, function (err) {
         if (err) {
-            context.dispatch('NAVIGATE_FAILURE', payload);
+            var error500 = {
+                statusCode: err.statusCode || 500,
+                message: err.message
+            };
+
+            context.dispatch('NAVIGATE_FAILURE', error500);
         } else {
-            context.dispatch('NAVIGATE_SUCCESS', payload);
+            context.dispatch('NAVIGATE_SUCCESS', route);
         }
+
         done(err);
     });
 };

--- a/tests/unit/lib/NavLink-test.js
+++ b/tests/unit/lib/NavLink-test.js
@@ -38,7 +38,7 @@ describe('NavLink', function () {
         mockContext = createMockComponentContext({
             stores: [TestRouteStore]
         });
-        mockContext.getStore('RouteStore').handleNavigateStart({
+        mockContext.getStore('RouteStore')._handleNavigateStart({
             url: '/foo',
             method: 'GET'
         });
@@ -345,7 +345,7 @@ describe('NavLink', function () {
             expect(link.getDOMNode().getAttribute('href')).to.equal('/foo');
             expect(link.getDOMNode().textContent).to.equal('bar');
             expect(link.getDOMNode().getAttribute('class')).to.equal('active');
-            mockContext.getStore('RouteStore').handleNavigateStart({
+            mockContext.getStore('RouteStore')._handleNavigateStart({
                 url: '/bar',
                 method: 'GET'
             });

--- a/tests/unit/lib/RouteStore-test.js
+++ b/tests/unit/lib/RouteStore-test.js
@@ -17,7 +17,7 @@ describe('RouteStore', function () {
         var routeStore;
         beforeEach(function () {
             routeStore = new StaticRouteStore();
-            routeStore.handleNavigateStart({
+            routeStore._handleNavigateStart({
                 url: '/foo',
                 method: 'get'
             });
@@ -47,7 +47,7 @@ describe('RouteStore', function () {
                     url: '/foo',
                     method: 'get'
                 });
-                expect(newStore.routes).to.equal(null);
+                expect(newStore._routes).to.equal(null);
             });
         });
     });
@@ -62,8 +62,8 @@ describe('RouteStore', function () {
         };
         beforeEach(function () {
             routeStore = new RouteStore();
-            routeStore.handleReceiveRoutes(routes);
-            routeStore.handleNavigateStart({
+            routeStore._handleReceiveRoutes(routes);
+            routeStore._handleNavigateStart({
                 url: '/foo',
                 method: 'get'
             });
@@ -93,7 +93,7 @@ describe('RouteStore', function () {
                     url: '/foo',
                     method: 'get'
                 });
-                expect(newStore.routes).to.deep.equal(routes);
+                expect(newStore._routes).to.deep.equal(routes);
             });
         });
     });

--- a/tests/unit/lib/handleHistory-test.js
+++ b/tests/unit/lib/handleHistory-test.js
@@ -92,7 +92,7 @@ describe ('handleHistory', function () {
         it('should pass the currentRoute as prop to child', function () {
             var rendered = false;
             var routeStore = mockContext.getStore('RouteStore');
-            routeStore.handleNavigateStart({url: '/foo', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/foo', method: 'GET'});
             var Child = React.createClass({
                 displayName: 'Child',
                 render: function () {
@@ -127,7 +127,7 @@ describe ('handleHistory', function () {
         });
         it ('listen to scroll event', function (done) {
             var routeStore = mockContext.getStore('RouteStore');
-            routeStore.handleNavigateStart({url: '/the_path_from_state', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/the_path_from_state', method: 'GET'});
             MockAppComponent = provideContext(handleHistory(MockAppComponent, {
                 historyCreator: function () {
                     return historyMock();
@@ -145,7 +145,7 @@ describe ('handleHistory', function () {
         });
         it ('dispatch navigate event for pages that url does not match', function (done) {
             var routeStore = mockContext.getStore('RouteStore');
-            routeStore.handleNavigateStart({url: '/the_path_from_state', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/the_path_from_state', method: 'GET'});
             MockAppComponent = provideContext(handleHistory(MockAppComponent, {
                 checkRouteOnPageLoad: true,
                 historyCreator: function () {
@@ -165,7 +165,7 @@ describe ('handleHistory', function () {
         });
         it ('does not dispatch navigate event for pages with matching url', function (done) {
             var routeStore = mockContext.getStore('RouteStore');
-            routeStore.handleNavigateStart({url: '/the_path_from_history', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/the_path_from_history', method: 'GET'});
             MockAppComponent = provideContext(handleHistory(MockAppComponent, {
                 historyCreator: function () {
                     return historyMock('/foo');
@@ -202,7 +202,7 @@ describe ('handleHistory', function () {
     describe('componentDidUpdate()', function () {
         it ('no-op on same route', function () {
             var routeStore = mockContext.getStore('RouteStore');
-            routeStore.handleNavigateStart({url: '/foo', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/foo', method: 'GET'});
             MockAppComponent = provideContext(handleHistory(MockAppComponent, {
                 historyCreator: function () {
                     return historyMock('/foo');
@@ -211,12 +211,12 @@ describe ('handleHistory', function () {
             ReactTestUtils.renderIntoDocument(
                 <MockAppComponent context={mockContext} />
             );
-            routeStore.handleNavigateStart({url: '/foo', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/foo', method: 'GET'});
             expect(testResult.pushState).to.equal(undefined);
         });
         it ('do not pushState, navigate.type=popstate', function () {
             var routeStore = mockContext.getStore('RouteStore');
-            routeStore.handleNavigateStart({url: '/foo', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/foo', method: 'GET'});
             MockAppComponent = provideContext(handleHistory(MockAppComponent, {
                 historyCreator: function () {
                     return historyMock('/foo');
@@ -225,12 +225,12 @@ describe ('handleHistory', function () {
             ReactTestUtils.renderIntoDocument(
                 <MockAppComponent context={mockContext} />
             );
-            routeStore.handleNavigateStart({url: '/bar', type: 'popstate', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/bar', type: 'popstate', method: 'GET'});
             expect(testResult.pushState).to.equal(undefined);
         });
         it ('update with different route, navigate.type=click, reset scroll position', function () {
             var routeStore = mockContext.getStore('RouteStore');
-            routeStore.handleNavigateStart({url: '/foo', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/foo', method: 'GET'});
             MockAppComponent = provideContext(handleHistory(MockAppComponent, {
                 historyCreator: function () {
                     return historyMock('/foo');
@@ -239,13 +239,13 @@ describe ('handleHistory', function () {
             ReactTestUtils.renderIntoDocument(
                 <MockAppComponent context={mockContext} />
             );
-            routeStore.handleNavigateStart({url: '/bar', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/bar', method: 'GET'});
             expect(testResult.pushState).to.eql({state: {params: {}, scroll: {x: 0, y: 0}}, title: null, url: '/bar'});
             expect(testResult.scrollTo).to.eql({x: 0, y: 0});
         });
         it ('update with different route, navigate.type=click, enableScroll=false, do not reset scroll position', function () {
             var routeStore = mockContext.getStore('RouteStore');
-            routeStore.handleNavigateStart({url: '/foo', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/foo', method: 'GET'});
             MockAppComponent = provideContext(handleHistory(MockAppComponent, {
                 enableScroll: false,
                 historyCreator: function () {
@@ -255,13 +255,13 @@ describe ('handleHistory', function () {
             ReactTestUtils.renderIntoDocument(
                 <MockAppComponent context={mockContext} />
             );
-            routeStore.handleNavigateStart({url: '/bar', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/bar', method: 'GET'});
             expect(testResult.pushState).to.eql({state: {params: {}}, title: null, url: '/bar'});
             expect(testResult.scrollTo).to.equal(undefined);
         });
         it ('update with different route, navigate.type=replacestate, enableScroll=false, do not reset scroll position', function () {
             var routeStore = mockContext.getStore('RouteStore');
-            routeStore.handleNavigateStart({url: '/foo', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/foo', method: 'GET'});
             MockAppComponent = provideContext(handleHistory(MockAppComponent, {
                 enableScroll: false,
                 historyCreator: function () {
@@ -271,13 +271,13 @@ describe ('handleHistory', function () {
             ReactTestUtils.renderIntoDocument(
                 <MockAppComponent context={mockContext} />
             );
-            routeStore.handleNavigateStart({url: '/bar', method: 'GET', type: 'replacestate'});
+            routeStore._handleNavigateStart({url: '/bar', method: 'GET', type: 'replacestate'});
             expect(testResult.replaceState).to.eql({state: {params: {}}, title: null, url: '/bar'});
             expect(testResult.scrollTo).to.equal(undefined);
         });
         it ('update with different route, navigate.type=default, reset scroll position', function () {
             var routeStore = mockContext.getStore('RouteStore');
-            routeStore.handleNavigateStart({url: '/foo', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/foo', method: 'GET'});
             MockAppComponent = provideContext(handleHistory(MockAppComponent, {
                 historyCreator: function () {
                     return historyMock('/foo');
@@ -286,13 +286,13 @@ describe ('handleHistory', function () {
             ReactTestUtils.renderIntoDocument(
                 <MockAppComponent context={mockContext} />
             );
-            routeStore.handleNavigateStart({url: '/bar', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/bar', method: 'GET'});
             expect(testResult.pushState).to.eql({state: {params: {}, scroll: {x: 0, y: 0} }, title: null, url: '/bar'});
             expect(testResult.scrollTo).to.eql({x: 0, y: 0});
         });
         it ('update with different route, navigate.type=default, enableScroll=false, do not reset scroll position', function () {
             var routeStore = mockContext.getStore('RouteStore');
-            routeStore.handleNavigateStart({url: '/foo', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/foo', method: 'GET'});
             MockAppComponent = provideContext(handleHistory(MockAppComponent, {
                 enableScroll: false,
                 historyCreator: function () {
@@ -302,13 +302,13 @@ describe ('handleHistory', function () {
             ReactTestUtils.renderIntoDocument(
                 <MockAppComponent context={mockContext} />
             );
-            routeStore.handleNavigateStart({url: '/bar', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/bar', method: 'GET'});
             expect(testResult.pushState).to.eql({state: {params: {}}, title: null, url: '/bar'});
             expect(testResult.scrollTo).to.equal(undefined);
         });
         it ('do not pushState, navigate.type=popstate, restore scroll position', function () {
             var routeStore = mockContext.getStore('RouteStore');
-            routeStore.handleNavigateStart({url: '/foo', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/foo', method: 'GET'});
             MockAppComponent = provideContext(handleHistory(MockAppComponent, {
                 historyCreator: function () {
                     return historyMock('/foo#hash1', {scroll: {x: 12, y: 200}});
@@ -317,13 +317,13 @@ describe ('handleHistory', function () {
             ReactTestUtils.renderIntoDocument(
                 <MockAppComponent context={mockContext} />
             );
-            routeStore.handleNavigateStart({url: '/bar', method: 'GET', type: 'popstate'});
+            routeStore._handleNavigateStart({url: '/bar', method: 'GET', type: 'popstate'});
             expect(testResult.pushState).to.equal(undefined);
             expect(testResult.scrollTo).to.eql({x: 12, y: 200});
         });
         it ('do not pushState, navigate.type=popstate, enableScroll=false, restore scroll position', function () {
             var routeStore = mockContext.getStore('RouteStore');
-            routeStore.handleNavigateStart({url: '/foo', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/foo', method: 'GET'});
             MockAppComponent = provideContext(handleHistory(MockAppComponent, {
                 enableScroll: false,
                 historyCreator: function () {
@@ -333,14 +333,14 @@ describe ('handleHistory', function () {
             ReactTestUtils.renderIntoDocument(
                 <MockAppComponent context={mockContext} />
             );
-            routeStore.handleNavigateStart({url: '/bar', method: 'GET', type: 'popstate'});
+            routeStore._handleNavigateStart({url: '/bar', method: 'GET', type: 'popstate'});
             expect(testResult.pushState).to.equal(undefined);
             expect(testResult.scrollTo).to.eql(undefined);
 
         });
         it ('update with different route, navigate.type=click, with params', function () {
             var routeStore = mockContext.getStore('RouteStore');
-            routeStore.handleNavigateStart({url: '/foo', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/foo', method: 'GET'});
             MockAppComponent = provideContext(handleHistory(MockAppComponent, {
                 historyCreator: function () {
                     return historyMock('/foo#hash1');
@@ -349,12 +349,12 @@ describe ('handleHistory', function () {
             ReactTestUtils.renderIntoDocument(
                 <MockAppComponent context={mockContext} />
             );
-            routeStore.handleNavigateStart({url: '/bar', type: 'click', params: {foo: 'bar'}});
+            routeStore._handleNavigateStart({url: '/bar', type: 'click', params: {foo: 'bar'}});
             expect(testResult.pushState).to.eql({state: {params: {foo: 'bar'}, scroll: {x: 0, y:0}}, title: null, url: '/bar'});
         });
         it ('update with same path and different hash, navigate.type=click, with params', function () {
             var routeStore = mockContext.getStore('RouteStore');
-            routeStore.handleNavigateStart({url: '/foo#hash1', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/foo#hash1', method: 'GET'});
             MockAppComponent = provideContext(handleHistory(MockAppComponent, {
                 historyCreator: function () {
                     return historyMock('/foo#hash1');
@@ -363,12 +363,12 @@ describe ('handleHistory', function () {
             ReactTestUtils.renderIntoDocument(
                 <MockAppComponent context={mockContext} />
             );
-            routeStore.handleNavigateStart({url: '/foo#hash2', type: 'click', params: {foo: 'bar'}});
+            routeStore._handleNavigateStart({url: '/foo#hash2', type: 'click', params: {foo: 'bar'}});
             expect(testResult.pushState).to.eql({state: {params: {foo: 'bar'}, scroll: {x: 0, y:0}}, title: null, url: '/foo#hash2'});
         });
         it ('update with different route, navigate.type=replacestate, with params', function () {
             var routeStore = mockContext.getStore('RouteStore');
-            routeStore.handleNavigateStart({url: '/foo', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/foo', method: 'GET'});
             MockAppComponent = provideContext(handleHistory(MockAppComponent, {
                 historyCreator: function () {
                     return historyMock('/foo');
@@ -377,12 +377,12 @@ describe ('handleHistory', function () {
             ReactTestUtils.renderIntoDocument(
                 <MockAppComponent context={mockContext} />
             );
-            routeStore.handleNavigateStart({url: '/bar', method: 'GET', type: 'replacestate', params: {foo: 'bar'}});
+            routeStore._handleNavigateStart({url: '/bar', method: 'GET', type: 'replacestate', params: {foo: 'bar'}});
             expect(testResult.replaceState).to.eql({state: {params: {foo: 'bar'}, scroll: {x: 0, y: 0}}, title: null, url: '/bar'});
         });
         it ('update with different route, navigate.type=replacestate', function () {
             var routeStore = mockContext.getStore('RouteStore');
-            routeStore.handleNavigateStart({url: '/foo', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/foo', method: 'GET'});
             MockAppComponent = provideContext(handleHistory(MockAppComponent, {
                 historyCreator: function () {
                     return historyMock('/foo', {scroll: {x: 42, y: 3}});
@@ -391,14 +391,14 @@ describe ('handleHistory', function () {
             ReactTestUtils.renderIntoDocument(
                 <MockAppComponent context={mockContext} />
             );
-            routeStore.handleNavigateStart({url: '/bar', method: 'GET', type: 'replacestate'});
+            routeStore._handleNavigateStart({url: '/bar', method: 'GET', type: 'replacestate'});
             expect(testResult.replaceState).to.eql({state: {params: {}, scroll: {x: 0, y: 0}}, title: null, url: '/bar'});
         });
         it ('update with different route, navigate.type=pushstate, preserve scroll state', function () {
             global.window.scrollX = 42;
             global.window.scrollY = 3;
             var routeStore = mockContext.getStore('RouteStore');
-            routeStore.handleNavigateStart({url: '/foo', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/foo', method: 'GET'});
             MockAppComponent = provideContext(handleHistory(MockAppComponent, {
                 historyCreator: function () {
                     return historyMock('/foo');
@@ -407,14 +407,14 @@ describe ('handleHistory', function () {
             ReactTestUtils.renderIntoDocument(
                 <MockAppComponent context={mockContext} />
             );
-            routeStore.handleNavigateStart({url: '/bar', method: 'GET', type: 'click', preserveScrollPosition: true});
+            routeStore._handleNavigateStart({url: '/bar', method: 'GET', type: 'click', preserveScrollPosition: true});
             expect(testResult.pushState).to.eql({state: {params: {}, scroll: {x: 42, y: 3}}, title: null, url: '/bar'});
         });
         it ('update with different route, navigate.type=replacestate, preserve scroll state', function () {
             global.window.scrollX = 42;
             global.window.scrollY = 3;
             var routeStore = mockContext.getStore('RouteStore');
-            routeStore.handleNavigateStart({url: '/foo', method: 'GET'});
+            routeStore._handleNavigateStart({url: '/foo', method: 'GET'});
             MockAppComponent = provideContext(handleHistory(MockAppComponent, {
                 historyCreator: function () {
                     return historyMock('/foo');
@@ -423,7 +423,7 @@ describe ('handleHistory', function () {
             ReactTestUtils.renderIntoDocument(
                 <MockAppComponent context={mockContext} />
             );
-            routeStore.handleNavigateStart({url: '/bar', method: 'GET', type: 'replacestate', preserveScrollPosition: true});
+            routeStore._handleNavigateStart({url: '/bar', method: 'GET', type: 'replacestate', preserveScrollPosition: true});
             expect(testResult.replaceState).to.eql({state: {params: {}, scroll: {x: 42, y: 3}}, title: null, url: '/bar'});
         });
     });

--- a/tests/unit/lib/navigateAction-test.js
+++ b/tests/unit/lib/navigateAction-test.js
@@ -67,7 +67,7 @@ describe('navigateAction', function () {
             expect(mockContext.dispatchCalls[0].name).to.equal('NAVIGATE_START');
             expect(mockContext.dispatchCalls[0].payload.url).to.equal('/');
             expect(mockContext.dispatchCalls[1].name).to.equal('NAVIGATE_SUCCESS');
-            expect(mockContext.dispatchCalls[1].payload.url).to.equal('/');
+            expect(mockContext.dispatchCalls[1].payload.get('url')).to.equal('/');
             done();
         });
     });
@@ -84,7 +84,7 @@ describe('navigateAction', function () {
             expect(route.toJS().query).to.eql({foo: 'bar', a: ['b', 'c'], bool: null}, 'query added to route payload for NAVIGATE_START' + JSON.stringify(route));
             expect(mockContext.dispatchCalls[1].name).to.equal('NAVIGATE_SUCCESS');
             route = mockContext.dispatchCalls[1].payload;
-            expect(route.url).to.equal(url);
+            expect(route.get('url')).to.equal(url);
             done();
         });
     });
@@ -105,7 +105,7 @@ describe('navigateAction', function () {
             expect(err).to.equal(undefined);
             expect(mockContext.dispatchCalls.length).to.equal(2);
             expect(mockContext.dispatchCalls[1].name).to.equal('NAVIGATE_SUCCESS');
-            expect(mockContext.dispatchCalls[1].payload.url).to.equal('/action');
+            expect(mockContext.dispatchCalls[1].payload.get('url')).to.equal('/action');
             expect(mockContext.executeActionCalls.length).to.equal(1);
             expect(mockContext.executeActionCalls[0].action).to.equal(routes.action.action);
             expect(mockContext.executeActionCalls[0].payload.get('url')).to.equal('/action');
@@ -120,7 +120,7 @@ describe('navigateAction', function () {
             expect(err).to.equal(undefined);
             expect(mockContext.dispatchCalls.length).to.equal(2);
             expect(mockContext.dispatchCalls[1].name).to.equal('NAVIGATE_SUCCESS');
-            expect(mockContext.dispatchCalls[1].payload.url).to.equal('/string');
+            expect(mockContext.dispatchCalls[1].payload.get('url')).to.equal('/string');
             expect(mockContext.executeActionCalls.length).to.equal(1);
             expect(mockContext.executeActionCalls[0].action).to.equal(fooAction);
             expect(mockContext.executeActionCalls[0].payload.get('url')).to.equal('/string');
@@ -135,7 +135,7 @@ describe('navigateAction', function () {
             expect(err).to.be.an('object');
             expect(mockContext.dispatchCalls.length).to.equal(2);
             expect(mockContext.dispatchCalls[1].name).to.equal('NAVIGATE_FAILURE');
-            expect(mockContext.dispatchCalls[1].payload.url).to.equal('/fail');
+            expect(mockContext.dispatchCalls[1].payload.message).to.equal(err.message);
             done();
         });
     });
@@ -171,7 +171,7 @@ describe('navigateAction', function () {
             expect(mockContext.dispatchCalls[0].name).to.equal('NAVIGATE_START');
             expect(mockContext.dispatchCalls[0].payload.url).to.equal('/post');
             expect(mockContext.dispatchCalls[1].name).to.equal('NAVIGATE_SUCCESS');
-            expect(mockContext.dispatchCalls[1].payload.url).to.equal('/post');
+            expect(mockContext.dispatchCalls[1].payload.get('url')).to.equal('/post');
             done();
         });
     });


### PR DESCRIPTION
An alternative approach to make error handling with routes less opinionated.

There are two main cases to handle:

 - where the route was not found (no match found)
 - where the is route but the route's action returned an error