### PR TITLE
no longer processing children of a navlink

### DIFF
--- a/lib/NavLink.js
+++ b/lib/NavLink.js
@@ -96,16 +96,6 @@ var NavLink = React.createClass({
     render: function() {
         var href = this._getHrefFromProps(this.props);
         var isActive = this.props.isActive(href);
-        var children = null;
-        if (this.props.children) {
-            if ('string' === typeof this.props.children) {
-                children = this.props.children;
-            } else {
-                children = React.Children.map(this.props.children, function (child) {
-                    return React.cloneElement(child, {isActive: isActive});
-                });
-            }
-        }
 
         var className = this.props.className;
         var style = this.props.style;
@@ -124,7 +114,7 @@ var NavLink = React.createClass({
                 className: className,
                 style: style
             }),
-            children
+            this.props.children
         );
     }
 });


### PR DESCRIPTION
We saw some unexpected behavior with different contents of `NavLink`.

```js
// this throws
<NavLink className={logoClasses} routeName="home" style={{ fontFamily: 'Montserrat' }}>
    <img src="/public/images/logo_small.svg" width="16" height="16" alt="Fluxible" style={{verticalAlign: 'baseline'}} />
    Fluxible
</NavLink>
```

```js
// this works
<NavLink className={logoClasses} routeName="home" style={{ fontFamily: 'Montserrat' }}>
    <img src="/public/images/logo_small.svg" width="16" height="16" alt="Fluxible" style={{verticalAlign: 'baseline'}} />
    <span>Fluxible</span>
</NavLink>
```

We had to wrap the word Fluxible in a `<span>`.