### PR TITLE
Add onbeforeunload support

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,3 +9,5 @@
     no-unused-vars: 0 // see https://github.com/babel/babel-eslint/issues/21
     no-underscore-dangle: 0
     yoda: 0
+    no-alert: false
+    new-cap: false

--- a/README.md
+++ b/README.md
@@ -42,6 +42,22 @@ $ npm install --save fluxible-router
 
 You can also look into this [polyfill.io polyfill service](https://cdn.polyfill.io/v1/).
 
+## onbeforeunload Support
+
+The `History` API does not allow `popstate` events to be cancelled, which results in `window.onbeforeunload()` methods not being triggered.  This is problematic for users, since application state could be lost when they navigate to a certain page without knowing the consequences.
+
+Our solution is to check for a `window.onbeforeunload()` method, prompt the user with `window.confirm()`, and then navigate to the correct route based on the confirmation.  If a route is cancelled by the user, we reset the page URL back to the original URL by using  the `History` `pushState()` method.
+
+To implement the `window.onbeforeunload()` method, you need to set it within the components that need user verification before leaving a page.  Here is an example:
+
+```javascript
+componentDidMount: function() {
+  window.onbeforeunload = function () {
+    return 'Make sure to save your changes before leaving this page!';
+  }
+}
+```
+
 ## Compatible React Versions
 
 | Compatible React Version | fluxible-router Version |

--- a/lib/NavLink.js
+++ b/lib/NavLink.js
@@ -84,14 +84,23 @@ var NavLink = React.createClass({
             href = href.substring(origin.length) || '/';
         }
 
-        var context = this.props.context || this.context;
         e.preventDefault();
-        context.executeAction(navigateAction, {
-            type: navType,
-            url: href,
-            preserveScrollPosition: this.props.preserveScrollPosition,
-            params: this.props.navParams
-        });
+
+        var context = this.props.context || this.context;
+        var onBeforeUnloadText = typeof window.onbeforeunload === 'function' ? window.onbeforeunload() : '';
+        var confirmResult = onBeforeUnloadText ? window.confirm(onBeforeUnloadText) : true;
+
+        if (confirmResult) {
+            // Removes the window.onbeforeunload method so that the next page will not be affected
+            window.onbeforeunload = null;
+
+            context.executeAction(navigateAction, {
+                type: navType,
+                url: href,
+                preserveScrollPosition: this.props.preserveScrollPosition,
+                params: this.props.navParams
+            });
+        }
     },
     render: function() {
         var href = this._getHrefFromProps(this.props);

--- a/lib/handleHistory.js
+++ b/lib/handleHistory.js
@@ -98,16 +98,43 @@ module.exports = function handleHistory(Component, opts) {
             this._scrollTimer = window.setTimeout(this._saveScrollPosition, 150);
         },
         _onHistoryChange: function (e) {
+            var props = this.props;
             var url = this._history.getUrl();
-            var currentUrl = this.props.currentRoute && this.props.currentRoute.get('url');
+            var currentRouteMap = props.currentRoute || Immutable.Map();
+            var currentUrl = currentRouteMap.get('url');
+            var onBeforeUnloadText = typeof window.onbeforeunload === 'function' ? window.onbeforeunload() : '';
+            var confirmResult = onBeforeUnloadText ? window.confirm(onBeforeUnloadText) : true;
+            var nav = props.currentNavigate || {};
+            var navParams = nav.params || {};
+            var enableScroll = this._enableScroll && nav.preserveScrollPosition;
+            var historyState = {
+                params: (nav.params || {}),
+                scroll: {
+                    x: (enableScroll ? window.scrollX : 0),
+                    y: (enableScroll ? window.scrollY : 0)
+                }
+            };
+
+            var pageTitle = navParams.pageTitle || null;
+
             debug('history listener invoked', e, url, currentUrl);
-            if (url !== currentUrl) {
-                this.context.executeAction(navigateAction, {
-                    type: TYPE_POPSTATE,
-                    url: url,
-                    params: (e.state && e.state.params)
-                });
+
+            if (!confirmResult) {
+                // Pushes the previous history state back on top to set the correct url
+                this._history.pushState(historyState, pageTitle, currentUrl);
+            } else {
+                if (url !== currentUrl) {
+                    // Removes the window.onbeforeunload method so that the next page will not be affected
+                    window.onbeforeunload = null;
+
+                    this.context.executeAction(navigateAction, {
+                        type: TYPE_POPSTATE,
+                        url: url,
+                        params: (e.state && e.state.params)
+                    });
+                }
             }
+
         },
         _saveScrollPosition: function (e) {
             var historyState = (this._history.getState && this._history.getState()) || {};

--- a/lib/navigateAction.js
+++ b/lib/navigateAction.js
@@ -2,6 +2,7 @@
  * Copyright 2015, Yahoo! Inc.
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
+
 var debug = require('debug')('navigateAction');
 
 module.exports = function (context, payload, done) {

--- a/tests/unit/lib/NavLink-test.js
+++ b/tests/unit/lib/NavLink-test.js
@@ -254,6 +254,28 @@ describe('NavLink', function () {
             }, 10);
         });
 
+        describe('window.onbeforeunload', function () {
+            beforeEach(function () {
+                global.window.confirm = function () { return false; };
+                global.window.onbeforeunload = function () {
+                    return 'this is a test';
+                };
+            });
+
+            it ('should not call context.executeAction when a user does not confirm the onbeforeunload method', function (done) {
+                var link = ReactTestUtils.renderIntoDocument(
+                    <MockAppComponent context={mockContext}>
+                        <NavLink href='/foo' followLink={false} />
+                    </MockAppComponent>
+                );
+                ReactTestUtils.Simulate.click(link.getDOMNode(), {button: 0});
+                window.setTimeout(function () {
+                    expect(mockContext.executeActionCalls.length).to.equal(0);
+                    done();
+                }, 10);
+            });
+        });
+
         it('should throw if context not available', function () {
             expect(function () {
                 try{

--- a/tests/unit/lib/handleHistory-test.js
+++ b/tests/unit/lib/handleHistory-test.js
@@ -179,6 +179,31 @@ describe ('handleHistory', function () {
                 done();
             }, 10);
         });
+        describe('window.onbeforeunload', function () {
+            beforeEach(function () {
+                global.window.confirm = function () { return false; };
+                global.window.onbeforeunload = function () {
+                    return 'this is a test';
+                };
+            });
+
+            it ('does not dispatch navigate event if there is a window.onbeforeunload method that the user does not confirm', function (done) {
+                var routeStore = mockContext.getStore('RouteStore');
+                routeStore._handleNavigateStart({url: '/the_path_from_history', method: 'GET'});
+                MockAppComponent = provideContext(handleHistory(MockAppComponent, {
+                    historyCreator: function () {
+                        return historyMock('/foo');
+                    }
+                }));
+                ReactTestUtils.renderIntoDocument(
+                    <MockAppComponent context={mockContext} />
+                );
+                window.setTimeout(function() {
+                    expect(testResult.dispatch).to.equal(undefined, JSON.stringify(testResult.dispatch));
+                    done();
+                }, 10);
+            });
+        });
     });
 
     describe('componentWillUnmount()', function () {


### PR DESCRIPTION
This handles the situation when a user leaves a particular page and the `window.onbeforeunload()` method needs to be called. #16 

**Note:** This is almost idential to the [flux-router-component PR](https://github.com/yahoo/flux-router-component/pull/97) that I created.