### PR TITLE
restore scroll position after popstate

### DIFF
--- a/lib/handleHistory.js
+++ b/lib/handleHistory.js
@@ -159,14 +159,13 @@ module.exports = function handleHistory(Component, opts) {
             var navParams = nav.params || {};
             var historyState;
 
-            if (nav.url === this._history.getUrl()) {
-                return;
-            }
-
             switch (navType) {
                 case TYPE_CLICK:
                 case TYPE_DEFAULT:
                 case TYPE_REPLACESTATE:
+                    if (nav.url === this._history.getUrl()) {
+                        return;
+                    }
                     historyState = {params: navParams};
                     if (options.enableScroll) {
                         if (nav.preserveScrollPosition) {

--- a/tests/unit/lib/handleHistory-test.js
+++ b/tests/unit/lib/handleHistory-test.js
@@ -342,7 +342,7 @@ describe ('handleHistory', function () {
             ReactTestUtils.renderIntoDocument(
                 <MockAppComponent context={mockContext} />
             );
-            routeStore._handleNavigateStart({url: '/bar', method: 'GET', type: 'popstate'});
+            routeStore._handleNavigateStart({url: '/foo#hash1', method: 'GET', type: 'popstate'});
             expect(testResult.pushState).to.equal(undefined);
             expect(testResult.scrollTo).to.eql({x: 12, y: 200});
         });
@@ -361,7 +361,6 @@ describe ('handleHistory', function () {
             routeStore._handleNavigateStart({url: '/bar', method: 'GET', type: 'popstate'});
             expect(testResult.pushState).to.equal(undefined);
             expect(testResult.scrollTo).to.eql(undefined);
-
         });
         it ('update with different route, navigate.type=click, with params', function () {
             var routeStore = mockContext.getStore('RouteStore');


### PR DESCRIPTION
A scrolling position seems not to be restored after popstate.

fix popstate test case `/foo#hash1 → /foo → /bar (pop)` to `/foo#hash1 → /foo → /foo#hash1 (pop)`