### PR TITLE
Adds `navigate` data to route payload

### DIFF
--- a/lib/RouteStore.js
+++ b/lib/RouteStore.js
@@ -73,6 +73,7 @@ var RouteStore = createStore({
             r.set('url', route.url);
             r.set('params', Immutable.fromJS(route.params));
             r.set('query', Immutable.fromJS(self._parseQueryString(matchedUrl)));
+            r.set('navigate', Immutable.fromJS(route.navigate));
         });
 
         return route;

--- a/tests/unit/lib/navigateAction-test.js
+++ b/tests/unit/lib/navigateAction-test.js
@@ -89,6 +89,24 @@ describe('navigateAction', function () {
         });
     });
 
+    it('should include navigate object on route match', function (done) {
+        var url = '/';
+        navigateAction(mockContext, {
+            url: url,
+            someKey1: 'someData',
+            someKey2: {
+                someKey3: ['a', 'b']
+            }
+        }, function (err) {
+            expect(err).to.equal(undefined);
+            expect(mockContext.dispatchCalls.length).to.equal(2);
+            expect(mockContext.dispatchCalls[0].name).to.equal('NAVIGATE_START');
+            var route = mockContext.getStore('RouteStore').getCurrentRoute();
+            expect(route.toJS().navigate).to.eql({url: url, someKey1: 'someData', someKey2: {someKey3: ['a', 'b']}}, 'navigate added to route payload for NAVIGATE_START' + JSON.stringify(route));
+            done();
+        });
+    });
+
     it('should not call execute action if there is no action', function (done) {
         navigateAction(mockContext, {
             url: '/'


### PR DESCRIPTION
According to the [docs](https://github.com/yahoo/fluxible-router/blob/master/docs/api/navigateAction.md), the payload passed to event handlers and actions as a result of invoking `navigateAction` should have a `navigate` key containing the data passed to `navigateAction`. This PR adds this behavior and associated test.