### PR TITLE
Fix issue with unicode url causing 2 state entries pushed on navigation

### DIFF
--- a/lib/History.js
+++ b/lib/History.js
@@ -5,6 +5,8 @@
 /*global window */
 'use strict';
 
+var objectAssign = require('object-assign');
+
 var EVENT_POPSTATE = 'popstate';
 
 function isUndefined(v) {
@@ -64,6 +66,20 @@ History.prototype = {
      * @return {String} The url string that denotes current route path and query
      */
     getUrl: function () {
+        // Use origUrl in the history state object first.  This is to fix the unicode
+        // url issue (for browsers supporting history state):
+        //   For urls containing unicode chars, window.location will automatically encode
+        //   these unicode chars.  Therefore url comparison logic in handleHistory.js will
+        //   break, because url in the currentNavigation of RouteStore is usually un-encoded.
+        //   "origUrl" saved in the state object is in the same form as in RouteStore. So
+        //   it is safer to use "origUrl" for comparison.
+        var state = this.getState();
+        var urlFromState = state && state.origUrl;
+        if (urlFromState) {
+            return urlFromState;
+        }
+
+        // fallback to what is the window.location
         var location = this.win.location;
         return location.pathname + location.search;
     },
@@ -80,7 +96,10 @@ History.prototype = {
         if (this._hasPushState) {
             title = isUndefined(title) ? win.document.title : title;
             url = isUndefined(url) ? win.location.href : url;
-            win.history.pushState(state, title, url);
+
+            // remember the original url in state, so that it can be used by getUrl()
+            var _state = objectAssign({origUrl: url}, state);
+            win.history.pushState(_state, title, url);
             this.setTitle(title);
         } else if (url) {
             win.location.href = url;
@@ -99,7 +118,10 @@ History.prototype = {
         if (this._hasPushState) {
             title = isUndefined(title) ? win.document.title : title;
             url = isUndefined(url) ? win.location.href : url;
-            win.history.replaceState(state, title, url);
+
+            // remember the original url in state, so that it can be used by getUrl()
+            var _state = objectAssign({origUrl: url}, state);
+            win.history.replaceState(_state, title, url);
             this.setTitle(title);
         } else if (url) {
             win.location.replace(url);

--- a/tests/unit/lib/History-test.js
+++ b/tests/unit/lib/History-test.js
@@ -84,6 +84,23 @@ describe('History', function () {
             var url = history.getUrl();
             expect(url).to.equal('/path/to/page');
         });
+        it ('has pushState, should use history.state.origUrl over location', function () {
+            var win = _.extend(windowMock.HTML5, {
+                history: {
+                    state: {
+                        origUrl: '/_url'
+                    }
+                },
+                location: {
+                    pathname: '/path/to/page',
+                    search: '',
+                    hash: '#/path/to/abc'
+                }
+            });
+            var history = new History({win: win});
+            var url = history.getUrl();
+            expect(url).to.equal('/_url');
+        });
         it ('has pushState with query', function () {
             var win = _.extend(windowMock.HTML5, {
                 location: {
@@ -158,25 +175,32 @@ describe('History', function () {
             var history = new History({win: win});
 
             history.pushState({foo: 'bar'});
-            expect(testResult.pushState.state).to.eql({foo: 'bar'});
+            expect(testResult.pushState.state).to.eql({origUrl: "/currentUrl", foo: 'bar'});
             expect(testResult.pushState.title).to.equal('current title');
             expect(testResult.pushState.url).to.equal('/currentUrl');
 
             history.pushState({foo: 'bar'}, 't');
-            expect(testResult.pushState.state).to.eql({foo: 'bar'});
+            expect(testResult.pushState.state).to.eql({origUrl: "/currentUrl", foo: 'bar'});
             expect(testResult.pushState.title).to.equal('t');
             expect(testResult.pushState.url).to.equal('/currentUrl');
 
             history.pushState({foo: 'bar'}, 't', '/url');
-            expect(testResult.pushState.state).to.eql({foo: 'bar'});
+            expect(testResult.pushState.state).to.eql({origUrl: "/url", foo: 'bar'});
             expect(testResult.pushState.title).to.equal('t');
             expect(testResult.pushState.url).to.equal('/url');
             expect(windowMock.HTML5.document.title).to.equal('t');
 
             history.pushState({foo: 'bar'}, 'tt', '/url?a=b&x=y');
-            expect(testResult.pushState.state).to.eql({foo: 'bar'});
+            expect(testResult.pushState.state).to.eql({origUrl: "/url?a=b&x=y", foo: 'bar'});
             expect(testResult.pushState.title).to.equal('tt');
             expect(testResult.pushState.url).to.equal('/url?a=b&x=y');
+            expect(windowMock.HTML5.document.title).to.equal('tt');
+
+            var unicodeUrl = '/post/128097060420/2015-fno-vogue全球購物夜-眾藝人名人共襄盛舉';
+            history.pushState({foo: 'bar'}, 'tt', unicodeUrl);
+            expect(testResult.pushState.state).to.eql({origUrl: unicodeUrl, foo: 'bar'});
+            expect(testResult.pushState.title).to.equal('tt');
+            expect(testResult.pushState.url).to.equal(unicodeUrl);
             expect(windowMock.HTML5.document.title).to.equal('tt');
         });
         it ('has pushState, Firefox', function () {
@@ -191,17 +215,17 @@ describe('History', function () {
             var history = new History({win: win});
 
             history.pushState({foo: 'bar'});
-            expect(testResult.pushState.state).to.eql({foo: 'bar'});
+            expect(testResult.pushState.state).to.eql({origUrl: "/currentUrl", foo: 'bar'});
             expect(testResult.pushState.title).to.equal('current title');
             expect(testResult.pushState.url).to.equal('/currentUrl');
 
             history.pushState({foo: 'bar'}, 't');
-            expect(testResult.pushState.state).to.eql({foo: 'bar'});
+            expect(testResult.pushState.state).to.eql({origUrl: "/currentUrl", foo: 'bar'});
             expect(testResult.pushState.title).to.equal('t');
             expect(testResult.pushState.url).to.equal('/currentUrl');
 
             history.pushState({foo: 'bar'}, 't', '/url');
-            expect(testResult.pushState.state).to.eql({foo: 'bar'});
+            expect(testResult.pushState.state).to.eql({origUrl: "/url", foo: 'bar'});
             expect(testResult.pushState.title).to.equal('t');
             expect(testResult.pushState.url).to.equal('/url');
         });
@@ -235,23 +259,23 @@ describe('History', function () {
             var history = new History({win: win});
 
             history.replaceState({foo: 'bar'});
-            expect(testResult.replaceState.state).to.eql({foo: 'bar'});
+            expect(testResult.replaceState.state).to.eql({origUrl: "/currentUrl", foo: 'bar'});
             expect(testResult.replaceState.title).to.equal('current title');
             expect(testResult.replaceState.url).to.equal('/currentUrl');
 
             history.replaceState({foo: 'bar'}, 't');
-            expect(testResult.replaceState.state).to.eql({foo: 'bar'});
+            expect(testResult.replaceState.state).to.eql({origUrl: "/currentUrl", foo: 'bar'});
             expect(testResult.replaceState.title).to.equal('t');
             expect(testResult.replaceState.url).to.equal('/currentUrl');
 
             history.replaceState({foo: 'bar'}, 't', '/url');
-            expect(testResult.replaceState.state).to.eql({foo: 'bar'});
+            expect(testResult.replaceState.state).to.eql({origUrl: "/url", foo: 'bar'});
             expect(testResult.replaceState.title).to.equal('t');
             expect(testResult.replaceState.url).to.equal('/url');
             expect(windowMock.HTML5.document.title).to.equal('t');
 
             history.replaceState({foo: 'bar'}, 'tt', '/url?a=b&x=y');
-            expect(testResult.replaceState.state).to.eql({foo: 'bar'});
+            expect(testResult.replaceState.state).to.eql({origUrl: "/url?a=b&x=y", foo: 'bar'});
             expect(testResult.replaceState.title).to.equal('tt');
             expect(testResult.replaceState.url).to.equal('/url?a=b&x=y', 'url has query');
             expect(windowMock.HTML5.document.title).to.equal('tt');
@@ -268,17 +292,17 @@ describe('History', function () {
             var history = new History({win: win});
 
             history.replaceState({foo: 'bar'});
-            expect(testResult.replaceState.state).to.eql({foo: 'bar'});
+            expect(testResult.replaceState.state).to.eql({origUrl: "/currentUrl", foo: 'bar'});
             expect(testResult.replaceState.title).to.equal('current title');
             expect(testResult.replaceState.url).to.equal('/currentUrl');
 
             history.replaceState({foo: 'bar'}, 't');
-            expect(testResult.replaceState.state).to.eql({foo: 'bar'});
+            expect(testResult.replaceState.state).to.eql({origUrl: "/currentUrl", foo: 'bar'});
             expect(testResult.replaceState.title).to.equal('t');
             expect(testResult.replaceState.url).to.equal('/currentUrl');
 
             history.replaceState({foo: 'bar'}, 't', '/url');
-            expect(testResult.replaceState.state).to.eql({foo: 'bar'});
+            expect(testResult.replaceState.state).to.eql({origUrl: "/url", foo: 'bar'});
             expect(testResult.replaceState.title).to.equal('t');
             expect(testResult.replaceState.url).to.equal('/url');
         });


### PR DESCRIPTION
@mridgway @redonkulus  cc:// @pumpikano

This issue was also described in https://github.com/yahoo/fluxible-router/issues/66.

It is because if you have unicode in the navigate url, History.getUrl() will return encoded string instead of the original url.  Therefore failing this url check: https://github.com/yahoo/fluxible-router/blob/228b123bc4f0a22151333a4aab6a6a48e0865c2c/lib/handleHistory.js#L158

This fix will work for modern browsers that support history pushState.  For older browsers, we'll leave it as a known issue.
