### PR TITLE
Dispatch success or failure only for the last navigateAction

### DIFF
--- a/lib/RouteStore.js
+++ b/lib/RouteStore.js
@@ -22,6 +22,7 @@ var RouteStore = createStore({
     initialize: function () {
         this._routes = null;
         this._currentUrl = null;
+        this._currentTransactionId = null;
         this._currentRoute = null;
         this._currentNavigate = null;
         this._currentNavigateError = null;
@@ -45,10 +46,16 @@ var RouteStore = createStore({
         this.emitChange();
     },
     _handleNavigateSuccess: function (route) {
+        if (this._currentTransactionId !== route.get('transactionId')) {
+            return;
+        }
         this._isNavigateComplete = true;
         this.emitChange();
     },
     _handleNavigateFailure: function (error) {
+        if (this._currentTransactionId !== error.transactionId) {
+            return;
+        }
         this._isNavigateComplete = true;
         this._currentNavigateError = error;
         this.emitChange();
@@ -115,6 +122,7 @@ var RouteStore = createStore({
     dehydrate: function () {
         return {
             currentUrl: this._currentUrl,
+            currentTransactionId: this._currentTransactionId,
             currentNavigate: this._currentNavigate,
             currentNavigateError: this._currentNavigateError,
             isNavigateComplete: this._isNavigateComplete,
@@ -124,6 +132,7 @@ var RouteStore = createStore({
     rehydrate: function (state) {
         this._routes = state.routes;
         this._currentUrl = state.currentUrl;
+        this._currentTransactionId = state.currentTransactionId;
         this._currentRoute = this._matchRoute(this._currentUrl, {method: 'GET'});
         this._currentNavigate = state.currentNavigate;
         this._isNavigateComplete = state.isNavigateComplete;

--- a/lib/RouteStore.js
+++ b/lib/RouteStore.js
@@ -43,6 +43,7 @@ var RouteStore = createStore({
         this._currentNavigateError = null;
         this._isNavigateComplete = false;
         this._currentUrl = payload.url;
+        this._currentTransactionId = payload.transactionId;
         this.emitChange();
     },
     _handleNavigateSuccess: function (route) {

--- a/lib/navigateAction.js
+++ b/lib/navigateAction.js
@@ -13,9 +13,7 @@ module.exports = function navigateAction (context, payload, done) {
     }
     payload.transactionId = context.rootId;
     debug('dispatching NAVIGATE_START', payload);
-    context.dispatch('NAVIGATE_START', Object.assign(payload, {
-        transactionId: context.rootId
-    }));
+    context.dispatch('NAVIGATE_START', payload);
 
     if (!routeStore.getCurrentRoute) {
         done(new Error('RouteStore has not implemented `getCurrentRoute` method.'));

--- a/lib/navigateAction.js
+++ b/lib/navigateAction.js
@@ -11,7 +11,12 @@ module.exports = function navigateAction (context, payload, done) {
         payload.url = routeStore.makePath(payload.routeName, payload.params);
         payload.routeName = null;
     }
-    payload.transactionId = context.rootId;
+
+    var transactionId = payload.transactionId || context.rootId;
+    if (!payload.transactionId) {
+        payload.transactionId = transactionId;
+    }
+
     debug('dispatching NAVIGATE_START', payload);
     context.dispatch('NAVIGATE_START', payload);
 
@@ -27,7 +32,7 @@ module.exports = function navigateAction (context, payload, done) {
         var error404 = {
             statusCode: 404,
             message: 'Url \'' + payload.url + '\' does not match any routes',
-            transactionId: context.rootId
+            transactionId: transactionId
         };
         context.dispatch('NAVIGATE_FAILURE', error404);
         done(Object.assign(new Error(), error404));
@@ -42,7 +47,7 @@ module.exports = function navigateAction (context, payload, done) {
 
     if (!action || 'function' !== typeof action) {
         debug('route has no action, dispatching without calling action');
-        context.dispatch('NAVIGATE_SUCCESS', route.set('transactionId', context.rootId));
+        context.dispatch('NAVIGATE_SUCCESS', route.set('transactionId', transactionId));
         done();
         return;
     }
@@ -53,13 +58,13 @@ module.exports = function navigateAction (context, payload, done) {
             var error500 = {
                 statusCode: err.statusCode || 500,
                 message: err.message,
-                transactionId: context.rootId
+                transactionId: transactionId
             };
 
             context.dispatch('NAVIGATE_FAILURE', error500);
             done(Object.assign(err, error500));
         } else {
-            context.dispatch('NAVIGATE_SUCCESS', route.set('transactionId', context.rootId));
+            context.dispatch('NAVIGATE_SUCCESS', route.set('transactionId', transactionId));
             done();
         }
     });

--- a/lib/navigateAction.js
+++ b/lib/navigateAction.js
@@ -11,8 +11,11 @@ module.exports = function navigateAction (context, payload, done) {
         payload.url = routeStore.makePath(payload.routeName, payload.params);
         payload.routeName = null;
     }
+    payload.transactionId = context.rootId;
     debug('dispatching NAVIGATE_START', payload);
-    context.dispatch('NAVIGATE_START', payload);
+    context.dispatch('NAVIGATE_START', Object.assign(payload, {
+        transactionId: context.rootId
+    }));
 
     if (!routeStore.getCurrentRoute) {
         done(new Error('RouteStore has not implemented `getCurrentRoute` method.'));
@@ -25,9 +28,9 @@ module.exports = function navigateAction (context, payload, done) {
     if (!route) {
         var error404 = {
             statusCode: 404,
-            message: 'Url \'' + payload.url + '\' does not match any routes'
+            message: 'Url \'' + payload.url + '\' does not match any routes',
+            transactionId: context.rootId
         };
-
         context.dispatch('NAVIGATE_FAILURE', error404);
         done(Object.assign(new Error(), error404));
         return;
@@ -41,27 +44,24 @@ module.exports = function navigateAction (context, payload, done) {
 
     if (!action || 'function' !== typeof action) {
         debug('route has no action, dispatching without calling action');
-        context.dispatch('NAVIGATE_SUCCESS', route);
+        context.dispatch('NAVIGATE_SUCCESS', route.set('transactionId', context.rootId));
         done();
         return;
     }
 
     debug('executing route action');
     context.executeAction(action, route, function (err) {
-        if (routeStore.getCurrentRoute().get('url') !== route.get('url')) {
-            done();
-            return;
-        }
         if (err) {
             var error500 = {
                 statusCode: err.statusCode || 500,
-                message: err.message
+                message: err.message,
+                transactionId: context.rootId
             };
 
             context.dispatch('NAVIGATE_FAILURE', error500);
             done(Object.assign(err, error500));
         } else {
-            context.dispatch('NAVIGATE_SUCCESS', route);
+            context.dispatch('NAVIGATE_SUCCESS', route.set('transactionId', context.rootId));
             done();
         }
     });

--- a/lib/navigateAction.js
+++ b/lib/navigateAction.js
@@ -48,6 +48,10 @@ module.exports = function navigateAction (context, payload, done) {
 
     debug('executing route action');
     context.executeAction(action, route, function (err) {
+        if (routeStore.getCurrentRoute().get('url') !== route.get('url')) {
+            done();
+            return;
+        }
         if (err) {
             var error500 = {
                 statusCode: err.statusCode || 500,

--- a/tests/unit/lib/navigateAction-test.js
+++ b/tests/unit/lib/navigateAction-test.js
@@ -26,13 +26,6 @@ describe('navigateAction', function () {
                 done();
             }
         },
-        slower_action: {
-            method: 'get',
-            path: '/slower_action',
-            action: function (context, payload, done) {
-                setTimeout(done, 10);
-            }
-        },
         fail: {
             method: 'get',
             path: '/fail',
@@ -140,21 +133,6 @@ describe('navigateAction', function () {
             expect(mockContext.executeActionCalls[0].payload.get('url')).to.equal('/action');
             done();
         });
-    });
-
-    it('should not dispatch failure or success for actions slower than subsequent actions', function (done) {
-        navigateAction(mockContext, {
-            url: '/slower_action'
-        }, function(err) {
-            expect(mockContext.dispatchCalls.length).to.equal(3);
-            expect(mockContext.dispatchCalls[0].payload.url).to.equal('/slower_action'); // start
-            expect(mockContext.dispatchCalls[1].payload.url).to.equal('/action'); // start
-            expect(mockContext.dispatchCalls[2].payload.get('url')).to.equal('/action'); // success
-            done();
-        });
-        navigateAction(mockContext, {
-            url: '/action'
-        }, new Function);
     });
 
     it('should call execute action if there is an action as a string', function (done) {

--- a/tests/unit/lib/navigateAction-test.js
+++ b/tests/unit/lib/navigateAction-test.js
@@ -14,7 +14,7 @@ describe('navigateAction', function () {
         home: {
             method: 'get',
             path: '/'
-        },        
+        },
         withParams: {
             method: 'get',
             path: '/withParams/:id'
@@ -24,6 +24,13 @@ describe('navigateAction', function () {
             path: '/action',
             action: function (context, payload, done) {
                 done();
+            }
+        },
+        slower_action: {
+            method: 'get',
+            path: '/slower_action',
+            action: function (context, payload, done) {
+                setTimeout(done, 10);
             }
         },
         fail: {
@@ -133,6 +140,21 @@ describe('navigateAction', function () {
             expect(mockContext.executeActionCalls[0].payload.get('url')).to.equal('/action');
             done();
         });
+    });
+
+    it('should not dispatch failure or success for actions slower than subsequent actions', function (done) {
+        navigateAction(mockContext, {
+            url: '/slower_action'
+        }, function(err) {
+            expect(mockContext.dispatchCalls.length).to.equal(3);
+            expect(mockContext.dispatchCalls[0].payload.url).to.equal('/slower_action'); // start
+            expect(mockContext.dispatchCalls[1].payload.url).to.equal('/action'); // start
+            expect(mockContext.dispatchCalls[2].payload.get('url')).to.equal('/action'); // success
+            done();
+        });
+        navigateAction(mockContext, {
+            url: '/action'
+        }, new Function);
     });
 
     it('should call execute action if there is an action as a string', function (done) {

--- a/tests/unit/lib/navigateAction-test.js
+++ b/tests/unit/lib/navigateAction-test.js
@@ -106,7 +106,7 @@ describe('navigateAction', function () {
             expect(mockContext.dispatchCalls.length).to.equal(2);
             expect(mockContext.dispatchCalls[0].name).to.equal('NAVIGATE_START');
             var route = mockContext.getStore('RouteStore').getCurrentRoute();
-            expect(route.toJS().navigate).to.eql({url: url, someKey1: 'someData', someKey2: {someKey3: ['a', 'b']}}, 'navigate added to route payload for NAVIGATE_START' + JSON.stringify(route));
+            expect(route.toJS().navigate).to.eql({transactionId: mockContext.rootId, url: url, someKey1: 'someData', someKey2: {someKey3: ['a', 'b']}}, 'navigate added to route payload for NAVIGATE_START' + JSON.stringify(route));
             done();
         });
     });


### PR DESCRIPTION
If more `navigateAction`s are called in sequence, the first actions should never dispatch failure or success since they get "invalidated" by the last action, which started a new navigation. 

The change in this PR makes `navigateAction` to check the URL of the route that the store is expecting to handle: if the action's callback refers to a different url, it does not dispatch `NAVIGATION_SUCCESS` or `NAVIGATION_FAILURE`.

See [this video](http://i.imgur.com/NN5QKNh.gifv) showing the problem this PR should solve: when the user clicks multiple times on the navigation bar, the URL may go out of sync with what is actually displayed on the page. The last clicked is the link to "components.html" but the page actually shown is the API for `Fluxible`. This is particularly visible on slow or irregular connections. I've seen this issue also in https://github.com/gpbl/isomorphic500/issues/44.

![nn5qknh - imgur](https://cloud.githubusercontent.com/assets/120693/10715326/5a757734-7b13-11e5-9d8f-727e32707f3f.gif)