### PR TITLE
Remove baseURI from History getUrl result

### DIFF
--- a/lib/History.js
+++ b/lib/History.js
@@ -6,6 +6,7 @@
 'use strict';
 
 var EVENT_POPSTATE = 'popstate';
+var url = require('url');
 
 function isUndefined(v) {
     return v === undefined;
@@ -74,6 +75,8 @@ History.prototype = {
         var state = this.getState();
         var urlFromState = state && state.origUrl;
         var location = this.win.location;
+        var baseURI = this.win.document.baseURI;
+        var strippedBaseURI;
 
         if (urlFromState) {
             // remove hostname from url
@@ -82,6 +85,12 @@ History.prototype = {
                 urlFromState = urlFromState.substring(prefix.length) || '/';
             }
             return urlFromState;
+        }
+
+        if (baseURI) {
+            strippedBaseURI = url.parse(baseURI).pathname.replace('/', '');
+
+            return location.pathname.substr(strippedBaseURI.length);
         }
 
         // fallback to what is the window.location

--- a/tests/unit/lib/History-test.js
+++ b/tests/unit/lib/History-test.js
@@ -128,6 +128,34 @@ describe('History', function () {
             win.history.state.origUrl = 'https://foo.com:4080/';
             expect(history.getUrl()).to.equal('/');
         });
+        it('has pushState, should remove baseURI from window.location.pathname', function () {
+            var win = _.extend(windowMock.HTML5, {
+                history: {
+                    state: {}
+                },
+                location: {
+                    protocol: 'https:',
+                    host: 'foo.com:4080',
+                    pathname: '/base/path/to/page',
+                    search: '',
+                    hash: ''
+                },
+                document: {
+                    baseURI: 'https://foo.com:4080/base/'
+                }
+            });
+            var history = new History({win: win});
+
+            expect(history.getUrl()).to.equal('/path/to/page');
+
+            win.document.baseURI = 'https://foo.com:4080/base/long/';
+            win.location.pathname = '/base/long/';
+            expect(history.getUrl()).to.equal('/');
+
+            win.document.baseURI = 'https://foo.com:4080/base/long/';
+            win.location.pathname = '/base/long/path/to/page';
+            expect(history.getUrl()).to.equal('/path/to/page');
+        });
         it ('has pushState with query', function () {
             var win = _.extend(windowMock.HTML5, {
                 location: {


### PR DESCRIPTION
If baseURI is set, history handling can't match the current Route to the one set in routes config. As a result, browser's url is shortened from:

 http://www.example.com/base/location/route

to

 http://www.example.com/route

This PR includes removal of the baseUrl part while getting the url from history module.