### PR TITLE
Fix rehydrate store for POST routes

### DIFF
--- a/lib/RouteStore.js
+++ b/lib/RouteStore.js
@@ -124,7 +124,9 @@ var RouteStore = createStore({
     rehydrate: function (state) {
         this._routes = state.routes;
         this._currentUrl = state.currentUrl;
-        this._currentRoute = this._matchRoute(this._currentUrl, {method: 'GET'});
+        this._currentRoute = this._matchRoute(this._currentUrl, {
+          method: state.currentNavigate && state.currentNavigate.method || 'GET'
+        });
         this._currentNavigate = state.currentNavigate;
         this._isNavigateComplete = state.isNavigateComplete;
         this._currentNavigateError = state.currentNavigateError;

--- a/tests/unit/lib/RouteStore-test.js
+++ b/tests/unit/lib/RouteStore-test.js
@@ -58,6 +58,10 @@ describe('RouteStore', function () {
             foo: {
                 path: '/foo',
                 method: 'get'
+            },
+            bar: {
+              path: '/bar',
+              method: 'post'
             }
         };
         beforeEach(function () {
@@ -92,6 +96,21 @@ describe('RouteStore', function () {
                 expect(newStore.getCurrentNavigate()).to.deep.equal({
                     url: '/foo',
                     method: 'get'
+                });
+                expect(newStore._routes).to.deep.equal(routes);
+            });
+
+            it('should rehydrate POST routes correctly', function() {
+                var newStore = new StaticRouteStore();
+                newStore.rehydrate({
+                    currentUrl: '/bar',
+                    currentNavigate: { url: '/bar', method: 'post' },
+                    routes: routes
+                });
+                expect(newStore.getCurrentRoute()).to.be.an('object');
+                expect(newStore.getCurrentNavigate()).to.deep.equal({
+                    url: '/bar',
+                    method: 'post'
                 });
                 expect(newStore._routes).to.deep.equal(routes);
             });


### PR DESCRIPTION
Using a POST route, the `RouteStore` rehydrates the app using the **static** `GET` value as method, so, when I'll open a POST url, the server side renders correctly, but in the client side returns 404 (if you don't defined the same route with GET method).

Now, `rehydrate` gets the route method from state (`state.currentNavigate.method`).
I had to check if it exists because in error pages (eg. 404) `currentNavigate` is `undefined`, so, I use `GET` as default.

Added unit test to ensure the behavior.