### PR TITLE
Pass route action's arguments to navigateAction's done callback

### DIFF
--- a/lib/navigateAction.js
+++ b/lib/navigateAction.js
@@ -58,7 +58,7 @@ module.exports = function navigateAction (context, payload, done) {
             done(Object.assign(err, error500));
         } else {
             context.dispatch('NAVIGATE_SUCCESS', route);
-            done();
+            done.apply(null, arguments);
         }
     });
 };


### PR DESCRIPTION
It would be useful to propagate the route action's arguments through to navigateAction's done callback. 

```
============
routes.js
============

module.exports = {
  thing: {
    path: '/thing',
    method: 'post',
    action: function(context, payload, done) {
      var res = payload.getIn(['navigate', 'body', 'foo']); // res === 'bar'
      done(null, res);
    }
  }
};

============
postThing.js
============

var payload = {
  url: '/thing',
  method: 'POST',
  body: { 
    foo: 'bar' 
  }
};

context.executeAction(navigateAction, payload, function(err, res) {
  if (err) {
    // throw err
  } else {
    // do something with `res`
  }
});
```

Currently, `res` is undefined in the above snippet