### PR TITLE
Fix "nav.params is not an object" error

### DIFF
--- a/lib/handleHistory.js
+++ b/lib/handleHistory.js
@@ -162,8 +162,8 @@ function createComponent(Component, opts) {
         componentDidUpdate: function (prevProps, prevState) {
             debug('component did update', prevState, this.props);
 
-            var nav = this.props.currentNavigate;
-            var navType = (nav && nav.type) || TYPE_DEFAULT;
+            var nav = this.props.currentNavigate || {};
+            var navType = nav.type || TYPE_DEFAULT;
             var navParams = nav.params || {};
             var historyState;
 


### PR DESCRIPTION
When FluxibleRouter does not match any routes, `handleHistory` component always throw `nav.params is not an object` error in client side.

This error occurred by `handleHistory:componentDidUpdate` try to get `params` from null (from `getDefaultProps`), so I fixed it.

Before
![](https://cloud.githubusercontent.com/assets/665440/11627836/e04922a4-9d30-11e5-89ac-27b96151b8e1.png)

After
![](https://cloud.githubusercontent.com/assets/665440/11627837/e086c776-9d30-11e5-8fdc-c25ab2e05ab9.png)